### PR TITLE
[UPD] ssi_revenue_recognition_operating_unit: operating unit on revenue recognition

### DIFF
--- a/ssi_revenue_recognition_operating_unit/__manifest__.py
+++ b/ssi_revenue_recognition_operating_unit/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Revenue Recognition + Operating Unit Integration",
-    "version": "14.0.3.1.0",
+    "version": "14.0.3.2.0",
     "website": "https://simetri-sinergi.id",
     "author": "OpenSynergy Indonesia, PT. Simetri Sinergi Indonesia",
     "license": "AGPL-3",
@@ -16,10 +16,13 @@
     "data": [
         "security/res_group/service_contract_performance_obligation.xml",
         "security/res_group/performance_obligation_acceptance.xml",
+        "security/res_group/revenue_recognition.xml",
         "security/ir_rule/service_contract_performance_obligation.xml",
         "security/ir_rule/performance_obligation_acceptance.xml",
+        "security/ir_rule/revenue_recognition.xml",
         "views/service_contract_performance_obligation_views.xml",
         "views/performance_obligation_acceptance_views.xml",
+        "views/revenue_recognition_views.xml",
     ],
     "images": [
         "static/description/banner.png",

--- a/ssi_revenue_recognition_operating_unit/migrations/14.0.3.2.0/post-migrate.py
+++ b/ssi_revenue_recognition_operating_unit/migrations/14.0.3.2.0/post-migrate.py
@@ -1,0 +1,36 @@
+# Copyright 2022 OpenSynergy Indonesia
+# Copyright 2022 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Post-migration for ssi_revenue_recognition_operating_unit 14.0.3.2.0.
+
+    Defensive fill of revenue_recognition.operating_unit_id from its performance
+    obligation. The field is newly added as a stored related on
+    performance_obligation_id.operating_unit_id so that performance obligation,
+    acceptance, and revenue recognition always share the same operating unit.
+    Odoo computes the stored related for existing rows during the module update;
+    this realign is an idempotent safety net that only touches rows whose stored
+    value differs from the performance obligation.
+    """
+    _logger.info(
+        "14.0.3.2.0 post-migrate: fill revenue_recognition.operating_unit_id from PoB"
+    )
+    openupgrade.logged_query(
+        cr,
+        """
+        UPDATE revenue_recognition rr
+        SET operating_unit_id = pob.operating_unit_id
+        FROM performance_obligation pob
+        WHERE rr.performance_obligation_id = pob.id
+          AND rr.operating_unit_id IS DISTINCT FROM pob.operating_unit_id
+        """,
+    )
+    _logger.info("14.0.3.2.0 post-migrate: done")

--- a/ssi_revenue_recognition_operating_unit/models/__init__.py
+++ b/ssi_revenue_recognition_operating_unit/models/__init__.py
@@ -5,4 +5,5 @@
 from . import (
     performance_obligation,
     performance_obligation_acceptance,
+    revenue_recognition,
 )

--- a/ssi_revenue_recognition_operating_unit/models/revenue_recognition.py
+++ b/ssi_revenue_recognition_operating_unit/models/revenue_recognition.py
@@ -1,0 +1,22 @@
+# Copyright 2022 OpenSynergy Indonesia
+# Copyright 2022 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class RevenueRecognition(models.Model):
+    _name = "revenue_recognition"
+    _inherit = [
+        "revenue_recognition",
+        "mixin.single_operating_unit",
+    ]
+
+    # Revenue recognition inherits its operating unit from its performance
+    # obligation, so performance obligation, acceptance, and revenue recognition
+    # always share the same operating unit.
+    operating_unit_id = fields.Many2one(
+        related="performance_obligation_id.operating_unit_id",
+        store=True,
+        default=False,
+    )

--- a/ssi_revenue_recognition_operating_unit/security/ir_rule/revenue_recognition.xml
+++ b/ssi_revenue_recognition_operating_unit/security/ir_rule/revenue_recognition.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 OpenSynergy Indonesia
+     Copyright 2022 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="revenue_recognition_rule_ou" model="ir.rule">
+    <field name="name">Revenue Recognition - Responsible to operating unit data</field>
+    <field name="model_id" ref="ssi_revenue_recognition.model_revenue_recognition" />
+    <field name="groups" eval="[(4, ref('revenue_recognition_ou_group'))]" />
+    <field
+            name="domain_force"
+        >[('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+    <field name="perm_unlink" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+</record>
+</odoo>

--- a/ssi_revenue_recognition_operating_unit/security/res_group/revenue_recognition.xml
+++ b/ssi_revenue_recognition_operating_unit/security/res_group/revenue_recognition.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 OpenSynergy Indonesia
+     Copyright 2022 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<!-- Data Ownership -->
+<record id="revenue_recognition_ou_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_revenue_recognition.revenue_recognition_data_ownership_module_category"
+        />
+</record>
+
+<record
+        id="ssi_revenue_recognition.revenue_recognition_company_group"
+        model="res.groups"
+    >
+    <field name="name">Company</field>
+    <field
+            name="category_id"
+            ref="ssi_revenue_recognition.revenue_recognition_data_ownership_module_category"
+        />
+    <field name="implied_ids" eval="[(4, ref('revenue_recognition_ou_group'))]" />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+</record>
+</odoo>

--- a/ssi_revenue_recognition_operating_unit/views/revenue_recognition_views.xml
+++ b/ssi_revenue_recognition_operating_unit/views/revenue_recognition_views.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 OpenSynergy Indonesia
+     Copyright 2022 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="revenue_recognition_view_tree" model="ir.ui.view">
+    <field name="name">revenue_recognition tree</field>
+    <field name="model">revenue_recognition</field>
+    <field
+            name="inherit_id"
+            ref="ssi_revenue_recognition.revenue_recognition_view_tree"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="revenue_recognition_view_search" model="ir.ui.view">
+    <field name="name">revenue_recognition search</field>
+    <field name="model">revenue_recognition</field>
+    <field
+            name="inherit_id"
+            ref="ssi_revenue_recognition.revenue_recognition_view_search"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='user_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+            <xpath expr="//filter[@name='grp_responsible']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by':'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="revenue_recognition_view_form" model="ir.ui.view">
+    <field name="name">revenue_recognition form</field>
+    <field name="model">revenue_recognition</field>
+    <field
+            name="inherit_id"
+            ref="ssi_revenue_recognition.revenue_recognition_view_form"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//group[@name='header_right']" position="inside">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+</odoo>


### PR DESCRIPTION
## What

Make **performance_obligation**, **performance_obligation_acceptance**, and
**revenue_recognition** always share the same operating unit.

`revenue_recognition` previously had no `operating_unit_id`. This adds it as a
stored related on `performance_obligation_id.operating_unit_id` (mirroring the
acceptance pattern), so the three models stay consistent by construction:

`contract → (bridge stamp) performance_obligation → (related) {acceptance, revenue_recognition}`

## Changes (ssi_revenue_recognition_operating_unit, 14.0.3.1.0 → 14.0.3.2.0)

* `models/revenue_recognition.py` — `_inherit [revenue_recognition, mixin.single_operating_unit]`; `operating_unit_id = related("performance_obligation_id.operating_unit_id", store=True, default=False)`.
* `security/res_group/revenue_recognition.xml` — OU group under the revenue recognition data-ownership category; company group implies it.
* `security/ir_rule/revenue_recognition.xml` — OU record rule (`operating_unit_id in user.operating_unit_ids`).
* `views/revenue_recognition_views.xml` — operating unit field in tree/search/form.
* `migrations/14.0.3.2.0/post-migrate.py` — defensive idempotent backfill from the performance obligation.

PoB-created-from-contract already inherits the contract operating unit via the
existing `ssi_service_revenue_recognition_operating_unit` bridge (unchanged).

## Verification

Installed on devel (exit 0, view xpaths resolve, service bridge auto-installs);
odoo shell confirms the related+stored field, record rule, and group wiring.
pre-commit green.