### PR TITLE
[UPD] ssi_revenue_recognition

### DIFF
--- a/ssi_revenue_recognition/views/account_analytic_account_views.xml
+++ b/ssi_revenue_recognition/views/account_analytic_account_views.xml
@@ -17,6 +17,19 @@
                 <field name="amount_total_pob" />
                 <field name="amount_diff_pob" />
             </xpath>
+            <xpath expr="//group[@name='main']" position="after">
+                <field name="pob_ids">
+                    <tree create="false" delete="false">
+                        <field name="name" />
+                        <field name="title" />
+                        <field name="product_id" />
+                        <field name="uom_quantity" />
+                        <field name="price_unit" />
+                        <field name="price_subtotal" sum="Total" />
+                        <field name="state" />
+                    </tree>
+                </field>
+            </xpath>
         </data>
     </field>
 </record>


### PR DESCRIPTION
Tambahkan field pob_ids ke form Analytic Account -- sebelumnya cuma total agregat (amount_total_pob/amount_diff_pob) yang tampil, rekapan/daftar Performance Obligation-nya sendiri tidak pernah ditambahkan ke view manapun. Pakai tree inline ringkas agar tidak keluar jalur dari lebar form.

Dilaporkan di ticket OFS/26/000024.