### PR TITLE
[UPD] ssi_revenue_recognition

### DIFF
--- a/.github/workflows/notify-telegram.yml
+++ b/.github/workflows/notify-telegram.yml
@@ -1,3 +1,30 @@
+# Caller tipis untuk reusable workflow `andhit-r/notify-telegram`.
+#
+# Seluruh logika notifikasi ada di hulu; berkas ini sengaja tidak memuat apa pun selain
+# trigger + pemanggilan, supaya perbaikan di hulu menyebar tanpa menyentuh repo modul.
+# JANGAN menyalin kembali logika inline ke sini — itu persis kebiasaan yang membuat satu
+# bug ikut tersalin ke 130 repo: Telegram menolak pesan lebih dari 4096 karakter dengan
+# `400 message is too long`, sehingga seluruh run CI jadi merah.
+#
+# Nilai branch di bawah diisi apply-ssi-overrides.sh sesuai versi repo (14.0, 19.0, …).
+# Placeholder-nya sengaja TIDAK disebut di komentar mana pun: substitusinya `sed` polos,
+# jadi penyebutan di komentar ikut tertimpa dan kalimatnya berubah jadi tak bermakna.
+#
+# Repo hulu bersifat PUBLIK, jadi repo di org mana pun — termasuk `open-synergy` — boleh
+# MEMANGGIL-nya; reusable workflow privat hanya bisa dipanggil repo milik owner yang sama.
+#
+# TAPI IZIN MEMANGGIL DAN PEWARISAN SECRET ADALAH DUA ATURAN BERBEDA. `secrets: inherit`
+# hanya bekerja bila pemanggil dan reusable workflow berada di organisasi/enterprise yang
+# SAMA. Repo `open-synergy/*` memanggil workflow milik user `andhit-r` — beda owner —
+# sehingga `inherit` TIDAK meneruskan secret org dan seluruh run gagal SEBELUM job jalan:
+#   Error when evaluating 'secrets'. ...
+#   Secret TELEGRAM_CODE_BOT_TOKEN is required, but not provided while calling.
+# Karena itu kedua secret DITERUSKAN EKSPLISIT di bawah: ekspresi `${{ secrets.* }}`
+# dievaluasi di konteks pemanggil, jadi secret level repo MAUPUN level org sama-sama
+# terbaca, lintas owner sekalipun. JANGAN kembalikan ke `secrets: inherit`.
+#
+# Secret yang wajib tersedia bagi repo modul (level repo ATAU level org):
+# TELEGRAM_CODE_BOT_TOKEN, TELEGRAM_CHAT_ID.
 name: Notify Telegram on Push
 
 on:
@@ -7,89 +34,7 @@ on:
 
 jobs:
   notify:
-    name: Send Telegram Notification
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Build and send Telegram message
-        # Semua data dinamis dilewatkan lewat env (di-set GitHub dengan aman),
-        # BUKAN ditanam ke skrip shell. Mencegah error sintaks & script injection
-        # bila pesan commit mengandung ' ` $() < > & atau karakter khusus lain.
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_CODE_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          REPO: ${{ github.repository }}
-          BRANCH: ${{ github.ref_name }}
-          PUSHER: ${{ github.actor }}
-          COMPARE_URL: ${{ github.event.compare }}
-          COMMITS_JSON: ${{ toJson(github.event.commits) }}
-        # Heredoc ber-quote <<'PYEOF': bash TIDAK menginterpolasi isi Python.
-        run: |
-          python3 <<'PYEOF'
-          import os, json, html, urllib.request, urllib.parse, urllib.error
-
-          repo    = os.environ["REPO"]
-          branch  = os.environ["BRANCH"]
-          pusher  = os.environ["PUSHER"]
-          compare = os.environ["COMPARE_URL"]
-          commits = json.loads(os.environ.get("COMMITS_JSON") or "[]")
-
-          # Telegram HTML hanya kenal &lt; &gt; &amp;; jangan escape kutip
-          # (entity numerik apostrof ditolak parser).
-          def esc(s):
-              return html.escape(s, quote=False)
-
-          lines = []
-          for c in commits:
-              sha    = c["id"][:7]
-              msg    = c["message"].strip()
-              author = esc(c["author"]["name"])
-              ts     = c["timestamp"][:16].replace("T", " ")  # YYYY-MM-DD HH:MM
-
-              msg_lines = msg.split("\n")
-              title = esc(msg_lines[0][:80])  # baris pertama, maks 80 karakter
-              body  = [esc(l) for l in msg_lines[1:] if l.strip()]
-
-              entry = f"  <code>{sha}</code> {title}\n    👤 {author}  🕐 {ts}"
-              if body:
-                  entry += "\n" + "\n".join(f"    {l}" for l in body)
-              lines.append(entry)
-
-          count = len(commits)
-          if count == 1:
-              header = f"📝 <b>1 commit baru</b> di <code>{esc(repo)}</code>"
-          else:
-              header = f"📦 <b>{count} commit baru</b> di <code>{esc(repo)}</code>"
-
-          message = (
-              f"{header}\n"
-              f"Branch: <code>{esc(branch)}</code>\n"
-              f"Pusher: @{esc(pusher)}\n\n"
-              + "\n\n".join(lines)
-              + f'\n\n🔗 <a href="{esc(compare)}">Lihat perubahan</a>'
-          )
-
-          data = urllib.parse.urlencode({
-              "chat_id": os.environ["TELEGRAM_CHAT_ID"],
-              "text": message,
-              "parse_mode": "HTML",
-              "disable_web_page_preview": "true",
-          }).encode()
-
-          url = f'https://api.telegram.org/bot{os.environ["TELEGRAM_BOT_TOKEN"]}/sendMessage'
-          try:
-              with urllib.request.urlopen(urllib.request.Request(url, data=data)) as resp:
-                  result = json.load(resp)
-          except urllib.error.HTTPError as e:
-              result = json.load(e)
-
-          print("Telegram response:", json.dumps(result, ensure_ascii=False))
-          if not result.get("ok"):
-              print("::error::Gagal kirim pesan Telegram")
-              raise SystemExit(1)
-          PYEOF
+    uses: andhit-r/notify-telegram/.github/workflows/notify.yml@v1
+    secrets:
+      TELEGRAM_CODE_BOT_TOKEN: ${{ secrets.TELEGRAM_CODE_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/ssi_revenue_recognition/models/account_analytic_account.py
+++ b/ssi_revenue_recognition/models/account_analytic_account.py
@@ -49,6 +49,10 @@ class AccountAnalyticAccount(models.Model):
         compute="_compute_amount_pob",
         store=True,
     )
+    pob_cost_revenue_count = fields.Integer(
+        string="# PoB Cost/Revenue",
+        compute="_compute_pob_cost_revenue_count",
+    )
 
     @api.depends("pob_ids", "pob_ids.price_subtotal", "pob_planned_amount")
     def _compute_amount_pob(self):
@@ -56,3 +60,37 @@ class AccountAnalyticAccount(models.Model):
             total = sum(p.price_subtotal for p in record.pob_ids)
             record.amount_total_pob = total
             record.amount_diff_pob = record.pob_planned_amount - total
+
+    @api.depends("pob_ids.analytic_account_id")
+    def _compute_pob_cost_revenue_count(self):
+        """Count analytic lines posted to this AA's PoBs' own accounts.
+
+        Each PoB gets its own dedicated analytic account once opened
+        (see performance_obligation._10_create_analytic_account),
+        separate from this source analytic account, so PoB revenue
+        recognition entries never land here directly. This aggregates
+        them for the PoB Cost/Revenue smart button.
+        """
+        AAL = self.env["account.analytic.line"]
+        for record in self:
+            pob_aa_ids = record.pob_ids.mapped("analytic_account_id").ids
+            record.pob_cost_revenue_count = AAL.search_count(
+                [("account_id", "in", pob_aa_ids)]
+            )
+
+    def action_open_pob_cost_revenue(self):
+        """Open analytic lines across all PoBs' own analytic accounts.
+
+        Complements the core 'Cost/Revenue' button, which only shows
+        lines posted directly to this source analytic account.
+        """
+        self.ensure_one()
+        return {
+            "name": "PoB Cost/Revenue",
+            "type": "ir.actions.act_window",
+            "res_model": "account.analytic.line",
+            "view_mode": "tree,form,graph,pivot",
+            "domain": [
+                ("account_id", "in", self.pob_ids.mapped("analytic_account_id").ids)
+            ],
+        }

--- a/ssi_revenue_recognition/tests/__init__.py
+++ b/ssi_revenue_recognition/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_account_analytic_account

--- a/ssi_revenue_recognition/tests/test_account_analytic_account.py
+++ b/ssi_revenue_recognition/tests/test_account_analytic_account.py
@@ -2,9 +2,9 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import tagged
-
 from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")

--- a/ssi_revenue_recognition/tests/test_account_analytic_account.py
+++ b/ssi_revenue_recognition/tests/test_account_analytic_account.py
@@ -1,0 +1,52 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import tagged
+
+from odoo_yaml_test import YamlTransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestAccountAnalyticAccount(YamlTransactionCase):
+    """Scenario tests for ``account.analytic.account`` PoB Cost/Revenue.
+
+    Covers OFS/26/000024: the core "Cost/Revenue" smart button only
+    shows analytic lines posted directly to an analytic account, but
+    revenue recognition journals for a contract's Performance
+    Obligations post to each PoB's own, separately auto-created
+    analytic account (see
+    ``performance_obligation._10_create_analytic_account``) -- never
+    to the source contract's own account. ``pob_cost_revenue_count``
+    and ``action_open_pob_cost_revenue`` aggregate those PoB-owned
+    accounts' lines so the recap is visible from the source account.
+    """
+
+    def test_account_analytic_account(self):
+        """Run the PoB Cost/Revenue compute scenario."""
+        self.run_yaml_scenario("test_data_account_analytic_account.yaml")
+
+    def test_action_open_pob_cost_revenue_returns_action(self):
+        """Assert the act_window dict returned by the smart button.
+
+        Pure Python -- trigger P1 (L-01: ``action: call`` in YAML
+        discards a method's return value, so the domain/res_model
+        this action builds cannot be asserted from YAML at all).
+        """
+        source_aa = self.env["account.analytic.account"].create(
+            {"name": "Test Source AA - action"}
+        )
+        pob_aa = self.env["account.analytic.account"].create(
+            {"name": "Test PoB AA - action"}
+        )
+        self.env["performance_obligation"].create(
+            {
+                "title": "Test PoB - action",
+                "source_analytic_account_id": source_aa.id,
+                "analytic_account_id": pob_aa.id,
+            }
+        )
+        action = source_aa.action_open_pob_cost_revenue()
+        self.assertEqual(action["res_model"], "account.analytic.line")
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["domain"], [("account_id", "in", [pob_aa.id])])

--- a/ssi_revenue_recognition/tests/test_data_account_analytic_account.yaml
+++ b/ssi_revenue_recognition/tests/test_data_account_analytic_account.yaml
@@ -1,0 +1,79 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "PoB Cost/Revenue count aggregates each PoB's own account"
+    steps:
+      - step: "Create source analytic account"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa"
+        values:
+          name: "Test Source AA - PoB Cost Revenue"
+
+      - step: "Create PoB's own analytic account"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "pob_aa"
+        values:
+          name: "Test PoB AA - PoB Cost Revenue"
+
+      - step: "Create PoB linking the source AA to its own AA"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob"
+        values:
+          title: "Test PoB - Cost Revenue"
+          source_analytic_account_id: "REC: source_aa.id"
+          analytic_account_id: "REC: pob_aa.id"
+
+      - step: "Source AA has no PoB cost/revenue before any transaction"
+        action: "assert"
+        target: "source_aa"
+        asserts:
+          pob_cost_revenue_count:
+            type: "value"
+            expected: 0
+
+      - step: "Post first analytic line to the PoB's own account"
+        action: "create"
+        model: "account.analytic.line"
+        save_as: "line_1"
+        values:
+          name: "Test line 1"
+          account_id: "REC: pob_aa.id"
+          amount: 1000.0
+
+      - step: "Post second analytic line to the PoB's own account"
+        action: "create"
+        model: "account.analytic.line"
+        save_as: "line_2"
+        values:
+          name: "Test line 2"
+          account_id: "REC: pob_aa.id"
+          amount: -500.0
+
+      - step: "Source AA now aggregates both lines via the PoB"
+        action: "assert"
+        target: "source_aa"
+        asserts:
+          pob_cost_revenue_count:
+            type: "value"
+            expected: 2
+
+      - step: "Post a line directly on the source AA, not via any PoB"
+        action: "create"
+        model: "account.analytic.line"
+        save_as: "line_direct"
+        values:
+          name: "Direct line on source AA"
+          account_id: "REC: source_aa.id"
+          amount: 999.0
+
+      - step: "Count is unchanged by lines posted directly on the source AA"
+        action: "assert"
+        target: "source_aa"
+        asserts:
+          pob_cost_revenue_count:
+            type: "value"
+            expected: 2


### PR DESCRIPTION
Tambah `pob_cost_revenue_count` & `action_open_pob_cost_revenue` di Analytic Account untuk merekap transaksi dari AA milik tiap PoB — sebelumnya tombol "Cost/Revenue" bawaan selalu kosong karena transaksi PoB tercatat di AA miliknya sendiri (auto-dibuat saat PoB dibuka), bukan di AA sumbernya.

Ref: OFS/26/000024