### PR TITLE
[UPD] ssi_revenue_recognition: source analytic account jadi parent AA milik PoB

### DIFF
--- a/.github/workflows/docstring-gate.yml
+++ b/.github/workflows/docstring-gate.yml
@@ -1,0 +1,284 @@
+# Gerbang docstring — memerahkan PR yang MENAMBAH class/method tanpa docstring.
+#
+# Aturannya milik skill `odoo-development`,
+# references/odoo-module-guidelines/10-docstring.md; berkas ini hanya menegakkannya
+# di CI. Salinan mekanis yang sama ada di `assets/verify-module.sh` skill itu — bila
+# salah satu diubah, ubah keduanya (kontrak validator §13 memakai kunci temuan yang
+# sama persis, jadi baris `.validator-exceptions` berlaku di dua-duanya).
+#
+# ── KENAPA WORKFLOW TERSENDIRI, BUKAN HOOK pre-commit ────────────────────────
+# `pre-commit run --all-files` di CI berjalan saat pohon kerja SAMA DENGAN HEAD, jadi
+# pembanding "apa yang baru" tidak ada dan hook seperti ini selalu hijau di sana —
+# hijau palsu. Workflow ini membandingkan HEAD PR dengan `merge-base` branch tujuan,
+# yang memang pembanding yang benar untuk "apa yang PR ini perkenalkan".
+#
+# ── KENAPA HANYA PELANGGARAN BARU ────────────────────────────────────────────
+# Korpus 14.0 memuat ~12.400 class/method tanpa docstring di 77 repo (sapuan 2026-08).
+# Memerahkan semuanya sekaligus tidak membuat satu docstring pun tertulis; ia hanya
+# membuat gerbang ini dimatikan. Yang ditahan karena itu HANYA simbol yang tak
+# berdocstring DAN belum ada di merge-base. Utang warisan diukur terpisah lewat
+# `audit-sweep.sh` (skill odoo-development-repo-ops), bukan di sini.
+#
+# Berkas ini identik di semua repo modul SSI dan semua seri Odoo — tanpa placeholder,
+# tanpa filter branch, supaya sync-config.sh bisa memverifikasinya byte-per-byte.
+name: docstring gate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docstring-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docstring-gate:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Wajib: merge-base tidak bisa dihitung dari checkout dangkal.
+          fetch-depth: 0
+      - name: Gerbang docstring (hanya pelanggaran baru)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "$BASE_REF"
+          MERGE_BASE="$(git merge-base "origin/$BASE_REF" HEAD)"
+          echo "Pembanding : origin/$BASE_REF @ $MERGE_BASE"
+          echo
+          python3 - "$MERGE_BASE" <<'PY'
+          import ast
+          import os
+          import subprocess
+          import sys
+
+          MERGE_BASE = sys.argv[1]
+          RULE = "setiap-class-method-punya-docstring"
+
+
+          def git(*args):
+              """Keluaran sebuah perintah git, atau None bila perintahnya gagal."""
+              proc = subprocess.run(
+                  ["git"] + list(args), capture_output=True, text=True
+              )
+              return proc.stdout if proc.returncode == 0 else None
+
+
+          # --- aturan pengecualian (CERMIN verify-module.sh; 10-docstring.md) ------
+          EXEMPT_EXACT = {"_insert_form_element", "_get_policy_field"}
+          ONCHANGE_PREFIX = ("onchange_", "_onchange_")
+
+
+          def real_body(fn):
+              """Statement body sebuah fungsi, tanpa baris docstring-nya."""
+              return fn.body[1:] if ast.get_docstring(fn) is not None else fn.body
+
+
+          def is_simple_onchange(fn):
+              """True bila onchange-nya Pattern A/B/C — reset/set field, titik.
+
+              decorator_list sengaja tidak ditelusuri: `@api.onchange("x")` sendiri
+              sebuah ``ast.Call``, dan menelusurinya membuat SETIAP onchange
+              terhitung tidak sederhana.
+              """
+              for st in real_body(fn):
+                  if not isinstance(st, (ast.Assign, ast.If)):
+                      return False
+                  for node in ast.walk(st):
+                      if isinstance(
+                          node,
+                          (
+                              ast.Call,
+                              ast.For,
+                              ast.While,
+                              ast.Try,
+                              ast.With,
+                              ast.Return,
+                              ast.Lambda,
+                          ),
+                      ):
+                          return False
+              return True
+
+
+          def doc_exempt(fn):
+              """True bila fungsi ini masuk pengecualian TERTUTUP 10-docstring.md."""
+              if fn.name in EXEMPT_EXACT:
+                  return True
+              if fn.name.startswith(ONCHANGE_PREFIX):
+                  return is_simple_onchange(fn)
+              if fn.name.startswith("_selection_"):
+                  return len(real_body(fn)) <= 1
+              return False
+
+
+          def missing_symbols(source):
+              """{nama simbol: lineno} untuk class/method tanpa docstring.
+
+              None bila sumbernya gagal di-parse — berkas yang sintaksnya rusak
+              ditagih flake8/pylint, dan menebak isinya di sini hanya menghasilkan
+              temuan palsu.
+              """
+              try:
+                  tree = ast.parse(source)
+              except SyntaxError:
+                  return None
+              found = {}
+              for node in ast.walk(tree):
+                  if not isinstance(
+                      node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+                  ):
+                      continue
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                      if doc_exempt(node):
+                          continue
+                  if ast.get_docstring(node) is None:
+                      found.setdefault(node.name, node.lineno)
+              return found
+
+
+          def module_root(path):
+              """Direktori modul Odoo terdekat di atas `path`, atau None."""
+              cur = os.path.dirname(path)
+              while cur:
+                  if os.path.isfile(os.path.join(cur, "__manifest__.py")):
+                      return cur
+                  parent = os.path.dirname(cur)
+                  if parent == cur:
+                      break
+                  cur = parent
+              return None
+
+
+          _baseline_cache = {}
+
+
+          def module_baseline(module):
+              """Nama simbol tanpa docstring di SELURUH modul, pada merge-base.
+
+              Pembandingnya sengaja setingkat MODUL, bukan per berkas. Standar SSI
+              mengizinkan struktur berkas ditata ulang selama XML ID & nama class utuh
+              (02-core-principles.md), dan perbandingan per berkas membaca pemindahan
+              class warisan sebagai "simbol baru" — lalu menuntut docstring untuk kode
+              yang tidak disentuh PR itu. Deteksi rename bawaan git tidak menutup
+              lubangnya: berkas yang dipindah SEKALIGUS diubah isinya jatuh di bawah
+              ambang kemiripan dan terbaca sebagai hapus + tambah.
+              """
+              if module not in _baseline_cache:
+                  names = set()
+                  listing = git("ls-tree", "-r", "--name-only", MERGE_BASE, "--", module)
+                  for path in (listing or "").splitlines():
+                      if not path.endswith(".py"):
+                          continue
+                      if os.path.basename(path) == "__init__.py":
+                          continue
+                      old_src = git("show", "%s:%s" % (MERGE_BASE, path))
+                      if not old_src:
+                          continue
+                      found = missing_symbols(old_src)
+                      if found:
+                          names.update(found)
+                  _baseline_cache[module] = names
+              return _baseline_cache[module]
+
+
+          _exc_cache = {}
+
+
+          def excepted(module, key):
+              """True bila kunci temuan ini tercakup <modul>/.validator-exceptions."""
+              if module not in _exc_cache:
+                  keys = set()
+                  path = os.path.join(module, ".validator-exceptions")
+                  if os.path.isfile(path):
+                      with open(path, encoding="utf-8") as fh:
+                          for raw in fh:
+                              line = raw.strip()
+                              if not line or line.startswith("#"):
+                                  continue
+                              head, sep, reason = line.partition(" -- ")
+                              if not sep or not reason.strip():
+                                  continue
+                              parts = head.split(None, 1)
+                              if len(parts) == 2 and parts[0] == "module":
+                                  keys.add(parts[1].strip())
+                  _exc_cache[module] = keys
+              return key in _exc_cache[module]
+
+
+          # --- berkas .py yang disentuh PR ini -------------------------------------
+          status = git("diff", "--name-status", "-M", MERGE_BASE, "HEAD")
+          if status is None:
+              sys.exit("ERROR: `git diff` terhadap merge-base gagal.")
+
+          pairs = []  # (path_baru, path_lama|None)
+          for line in status.splitlines():
+              cols = line.split("\t")
+              code = cols[0]
+              if code.startswith("D"):
+                  continue
+              if code.startswith("R") and len(cols) == 3:
+                  pairs.append((cols[2], cols[1]))
+              elif len(cols) >= 2:
+                  pairs.append((cols[1], cols[1]))
+
+          findings = []
+          checked = 0
+          for new_path, old_path in pairs:
+              if not new_path.endswith(".py"):
+                  continue
+              if os.path.basename(new_path) == "__init__.py":
+                  continue
+              # setup/ hanya berisi symlink hasil setuptools-odoo.
+              if new_path.startswith("setup/"):
+                  continue
+              if not os.path.isfile(new_path):
+                  continue
+              with open(new_path, encoding="utf-8") as fh:
+                  new_missing = missing_symbols(fh.read())
+              if new_missing is None:
+                  continue
+              checked += 1
+              module = module_root(new_path)
+              if module:
+                  baseline = module_baseline(module)
+              else:
+                  # Di luar modul Odoo (skrip lepas): tak ada modul untuk dibandingkan,
+                  # jadi pembandingnya kembali ke berkas itu sendiri di merge-base.
+                  old_src = git("show", "%s:%s" % (MERGE_BASE, old_path)) if old_path else None
+                  baseline = set(missing_symbols(old_src) or {}) if old_src else set()
+              for name, lineno in sorted(new_missing.items(), key=lambda kv: kv[1]):
+                  if name in baseline:
+                      continue  # utang warisan — diukur audit-sweep.sh, bukan di sini
+                  rel = os.path.relpath(new_path, module) if module else new_path
+                  if module and excepted(module, "%s|%s %s" % (RULE, rel, name)):
+                      print("  ⊘ %s:%d %s  [.validator-exceptions]" % (new_path, lineno, name))
+                      continue
+                  findings.append((new_path, lineno, name))
+
+          print("Berkas .py diperiksa: %d" % checked)
+          if not findings:
+              print("")
+              print("LOLOS: tidak ada class/method baru tanpa docstring.")
+              sys.exit(0)
+
+          print("")
+          print("GAGAL: %d class/method BARU tanpa docstring." % len(findings))
+          print("")
+          for path, lineno, name in findings:
+              print("  ✗ %s:%d %s" % (path, lineno, name))
+          print("")
+          print("Aturannya: skill odoo-development,")
+          print("  references/odoo-module-guidelines/10-docstring.md")
+          print("Reproduksi & perbaiki di lokal:")
+          print("  assets/vs-head.sh verify-module.sh <path-modul>")
+          print("")
+          print("Pengecualiannya TERTUTUP. Bila sebuah temuan memang tidak boleh")
+          print("diperbaiki, daftarkan di <modul>/.validator-exceptions berikut")
+          print("alasannya (kontrak validator §13) — jangan matikan gerbang ini.")
+          sys.exit(1)
+          PY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,17 @@ jobs:
         env:
           PIP_INDEX_URL: https://pypi.org/simple
           PIP_EXTRA_INDEX_URL: https://${{ secrets.SSI_PYPI_USER }}:${{ secrets.SSI_PYPI_PASSWORD }}@osmium.simetri-sinergi.biz.id/simple/
+      - name: Pre-install chart of accounts
+        # Memasang l10n_generic_coa ke DB test SEBELUM `oca_init_test_database`.
+        # Saat modul ini berstatus `to install`, pemeriksaan `to_install_l10n`
+        # (account/__init__.py) bernilai benar sehingga `_auto_install_l10n`
+        # berhenti tanpa memasang l10n_us; chart of accounts juga sudah termuat
+        # sebelum demo modul SSI lahir, sehingga `chart_template._load()` tidak
+        # pernah menghapus account.journal/account.account yang dirujuk demo.
+        # Demo TIDAK dimatikan: tour dan skenario uji bergantung padanya.
+        run: |
+          oca_wait_for_postgres
+          odoo -d "$PGDATABASE" -i l10n_generic_coa --http-interface=127.0.0.1 --stop-after-init
       - name: Check licenses
         run: manifestoo -d . check-licenses
         continue-on-error: true

--- a/ssi_revenue_recognition/__manifest__.py
+++ b/ssi_revenue_recognition/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Revenue Recognition",
-    "version": "14.0.8.2.0",
+    "version": "14.0.8.3.0",
     "website": "https://simetri-sinergi.id",
     "author": "OpenSynergy Indonesia, PT. Simetri Sinergi Indonesia",
     "license": "AGPL-3",

--- a/ssi_revenue_recognition/migrations/14.0.8.3.0/post-migrate.py
+++ b/ssi_revenue_recognition/migrations/14.0.8.3.0/post-migrate.py
@@ -1,0 +1,63 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Post-migration for 14.0.8.3.0.
+
+    Backfill ``parent_id`` on every analytic account owned by a
+    Performance Obligation so it sits directly below the analytic
+    account of its contract (``source_analytic_account_id``).
+
+    Until this version ``performance_obligation._prepare_analytic_account``
+    left ``parent_id`` empty, so each PoB analytic account was created as
+    a root and the "contract analytic account -> PoB analytic account"
+    hierarchy never existed for existing data.
+
+    Written through the ORM on purpose -- not with
+    ``openupgrade.logged_query`` like the earlier migrations of this
+    module -- because ``account.analytic.account.complete_name`` is a
+    stored compute and OCA ``account_analytic_parent`` maintains
+    ``parent_path``; neither is refreshed by raw SQL writes.
+
+    Idempotent and conditional: only PoBs that have both an analytic
+    account and a source analytic account, that are not the very same
+    record, and whose analytic account does not already point at that
+    source, are written.  Re-running the script matches nothing.
+
+    :param cr: database cursor
+    :param version: version the module is upgraded from
+    """
+    _logger.info("14.0.8.3.0 post-migrate: backfill PoB analytic parent")
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    obligations = env["performance_obligation"].search(
+        [
+            ("analytic_account_id", "!=", False),
+            ("source_analytic_account_id", "!=", False),
+        ]
+    )
+    to_backfill = obligations.filtered(
+        lambda pob: pob.analytic_account_id != pob.source_analytic_account_id
+        and pob.analytic_account_id.parent_id != pob.source_analytic_account_id
+    )
+
+    counter = 0
+    for source in to_backfill.mapped("source_analytic_account_id"):
+        accounts = to_backfill.filtered(
+            lambda pob, source=source: pob.source_analytic_account_id == source
+        ).mapped("analytic_account_id")
+        accounts.write({"parent_id": source.id})
+        counter += len(accounts)
+
+    _logger.info(
+        "14.0.8.3.0 post-migrate: done, %s analytic account(s) reparented",
+        counter,
+    )

--- a/ssi_revenue_recognition/models/performance_obligation.py
+++ b/ssi_revenue_recognition/models/performance_obligation.py
@@ -8,6 +8,15 @@ from odoo.addons.ssi_decorator import ssi_decorator
 
 
 class PerformanceObligation(models.Model):
+    """
+    Represents one Performance Obligation (PoB) of a contract under
+    PSAK 115 / IFRS 15: a distinct promised good or service whose revenue
+    is recognised separately from the rest of the contract.
+    Each PoB owns its own analytic account, created when the document is
+    opened and placed below the contract's source analytic account, so
+    cost and revenue stay traceable per obligation.
+    """
+
     _name = "performance_obligation"
     _inherit = [
         "mixin.transaction_cancel",
@@ -362,6 +371,33 @@ class PerformanceObligation(models.Model):
         self.ensure_one()
         return self.source_analytic_account_id.group_id.id or False
 
+    def _get_analytic_parent_id(self):
+        """Resolve the parent of the analytic account owned by this PoB.
+
+        ``source_analytic_account_id`` -- the contract's own analytic
+        account -- is the single source of truth for that parent: every
+        analytic account a PoB owns sits directly below it in the
+        ``account.analytic.account`` hierarchy, so ``complete_name`` and
+        hierarchy-based analytic reports group each PoB under its
+        contract instead of showing it as another root account.
+
+        Returns ``False`` when no source account is set, and also when
+        the source account *is* this PoB's own analytic account: OCA
+        ``account_analytic_parent`` raises ``UserError`` on recursive
+        hierarchies, so a record must never become its own parent.
+
+        Extension point: override to place the PoB analytic account
+        somewhere else in the hierarchy.
+
+        :return: id of the parent ``account.analytic.account``, or
+            ``False`` when the account has to stay a root
+        """
+        self.ensure_one()
+        source = self.source_analytic_account_id
+        if not source or source == self.analytic_account_id:
+            return False
+        return source.id
+
     @ssi_decorator.post_open_action()
     def _10_create_analytic_account(self):
         self.ensure_one()
@@ -381,23 +417,47 @@ class PerformanceObligation(models.Model):
         self.analytic_account_id.write(self._prepare_update_analytic_account())
 
     def _prepare_update_analytic_account(self):
+        """Build the values resyncing the analytic account of this PoB.
+
+        Called by ``_update_analytic_account`` when the PoB already owns
+        an analytic account.  Every key is overwritten unconditionally --
+        ``parent_id`` included, since its only source of truth is
+        ``source_analytic_account_id`` -- so moving the PoB to another
+        contract moves its analytic account in the hierarchy as well.
+
+        Extension point: override to resync additional fields.
+
+        :return: dict of ``account.analytic.account`` values
+        """
         self.ensure_one()
         return {
             "name": self.title,
             "code": self.name,
             "partner_id": self.partner_id.id,
             "group_id": self._get_analytic_group_id(),
+            "parent_id": self._get_analytic_parent_id(),
             "date_start": self.date_start,
             "date_end": self.date_end,
         }
 
     def _prepare_analytic_account(self):
+        """Build the values of the analytic account owned by this PoB.
+
+        Called by ``_10_create_analytic_account`` when the PoB does not
+        own an analytic account yet.  ``parent_id`` puts the new account
+        directly below ``source_analytic_account_id``.
+
+        Extension point: override to add fields to the new account.
+
+        :return: dict of ``account.analytic.account`` values
+        """
         self.ensure_one()
         return {
             "name": self.title,
             "code": self.name,
             "partner_id": self.partner_id.id,
             "group_id": self._get_analytic_group_id(),
+            "parent_id": self._get_analytic_parent_id(),
             "date_start": self.date_start,
             "date_end": self.date_end,
         }

--- a/ssi_revenue_recognition/tests/__init__.py
+++ b/ssi_revenue_recognition/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_account_analytic_account
+from . import test_performance_obligation

--- a/ssi_revenue_recognition/tests/test_data_performance_obligation.yaml
+++ b/ssi_revenue_recognition/tests/test_data_performance_obligation.yaml
@@ -1,0 +1,208 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "New PoB analytic account is created below the source account"
+    steps:
+      - step: "Create analytic group of the source account"
+        action: "create"
+        model: "account.analytic.group"
+        save_as: "group_1"
+        values:
+          name: "Test AA Group - PoB Parent 1"
+
+      - step: "Create source analytic account of the contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_1"
+        values:
+          name: "Test Source AA - PoB Parent 1"
+          group_id: "REC: group_1.id"
+
+      - step: "Create draft PoB pointing at the source analytic account"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_1"
+        values:
+          title: "Test PoB - Parent 1"
+          source_analytic_account_id: "REC: source_aa_1.id"
+
+      - step: "PoB owns no analytic account yet"
+        action: "assert"
+        target: "pob_1"
+        asserts:
+          analytic_account_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Create the analytic account owned by the PoB"
+        action: "call"
+        target: "pob_1"
+        method: "_10_create_analytic_account"
+
+      - step: "New analytic account is a child of the source account"
+        action: "assert"
+        target: "pob_1"
+        asserts:
+          analytic_account_id:
+            type: "value"
+            operator: "is_truthy"
+          analytic_account_id.parent_id:
+            type: "m2o"
+            expected: "REC: source_aa_1"
+          analytic_account_id.group_id:
+            type: "m2o"
+            expected: "REC: group_1"
+          analytic_account_id.name:
+            type: "value"
+            expected: "Test PoB - Parent 1"
+
+  - name: "Existing PoB analytic account is reparented on rerun"
+    steps:
+      - step: "Create analytic group of the source account"
+        action: "create"
+        model: "account.analytic.group"
+        save_as: "group_2"
+        values:
+          name: "Test AA Group - PoB Parent 2"
+
+      - step: "Create source analytic account of the contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_2"
+        values:
+          name: "Test Source AA - PoB Parent 2"
+          group_id: "REC: group_2.id"
+
+      - step: "Create a root analytic account owned by the PoB"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "pob_aa_2"
+        values:
+          name: "Test PoB AA - PoB Parent 2"
+
+      - step: "Create draft PoB already owning that analytic account"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_2"
+        values:
+          title: "Test PoB - Parent 2"
+          source_analytic_account_id: "REC: source_aa_2.id"
+          analytic_account_id: "REC: pob_aa_2.id"
+
+      - step: "Analytic account of the PoB is still a root account"
+        action: "assert"
+        target: "pob_aa_2"
+        asserts:
+          parent_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Rerun the analytic account hook on the PoB"
+        action: "call"
+        target: "pob_2"
+        method: "_10_create_analytic_account"
+
+      - step: "Existing account is kept and reparented, not replaced"
+        action: "assert"
+        target: "pob_2"
+        asserts:
+          analytic_account_id:
+            type: "m2o"
+            expected: "REC: pob_aa_2"
+          analytic_account_id.parent_id:
+            type: "m2o"
+            expected: "REC: source_aa_2"
+          analytic_account_id.group_id:
+            type: "m2o"
+            expected: "REC: group_2"
+
+  - name: "Moving the source account moves the analytic parent along"
+    steps:
+      - step: "Create the first source analytic account"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_3a"
+        values:
+          name: "Test Source AA - PoB Parent 3A"
+
+      - step: "Create the second source analytic account"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_3b"
+        values:
+          name: "Test Source AA - PoB Parent 3B"
+
+      - step: "Create draft PoB on the first source account"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_3"
+        values:
+          title: "Test PoB - Parent 3"
+          source_analytic_account_id: "REC: source_aa_3a.id"
+
+      - step: "Create the analytic account owned by the PoB"
+        action: "call"
+        target: "pob_3"
+        method: "_10_create_analytic_account"
+
+      - step: "Parent is the first source account"
+        action: "assert"
+        target: "pob_3"
+        asserts:
+          analytic_account_id.parent_id:
+            type: "m2o"
+            expected: "REC: source_aa_3a"
+
+      - step: "Move the PoB to the second source account"
+        action: "write"
+        target: "pob_3"
+        values:
+          source_analytic_account_id: "REC: source_aa_3b.id"
+
+      - step: "Rerun the analytic account hook on the PoB"
+        action: "call"
+        target: "pob_3"
+        method: "_10_create_analytic_account"
+
+      - step: "Parent follows the new source account unconditionally"
+        action: "assert"
+        target: "pob_3"
+        asserts:
+          analytic_account_id.parent_id:
+            type: "m2o"
+            expected: "REC: source_aa_3b"
+
+  - name: "PoB whose analytic account is the source keeps no parent"
+    steps:
+      - step: "Create the analytic account shared by PoB and contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "shared_aa_4"
+        values:
+          name: "Test Shared AA - PoB Parent 4"
+
+      - step: "Create draft PoB owning its own source account"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_4"
+        values:
+          title: "Test PoB - Parent 4"
+          source_analytic_account_id: "REC: shared_aa_4.id"
+          analytic_account_id: "REC: shared_aa_4.id"
+
+      - step: "Rerun the hook: the self-parent guard must not raise"
+        action: "call"
+        target: "pob_4"
+        method: "_10_create_analytic_account"
+
+      - step: "Account is unchanged and stays a root account"
+        action: "assert"
+        target: "pob_4"
+        asserts:
+          analytic_account_id:
+            type: "m2o"
+            expected: "REC: shared_aa_4"
+          analytic_account_id.parent_id:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_revenue_recognition/tests/test_performance_obligation.py
+++ b/ssi_revenue_recognition/tests/test_performance_obligation.py
@@ -1,0 +1,25 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPerformanceObligation(YamlTransactionCase):
+    """Scenario tests for ``performance_obligation`` analytic parenting.
+
+    Covers the analytic account a Performance Obligation owns: on
+    ``_10_create_analytic_account`` it must end up directly below the
+    contract's ``source_analytic_account_id`` in the
+    ``account.analytic.account`` hierarchy, on both the create and the
+    update path, and it must stay a root when the source account is the
+    PoB's own analytic account (OCA ``account_analytic_parent`` forbids
+    recursive hierarchies).
+    """
+
+    def test_performance_obligation(self):
+        """Run the PoB analytic account parenting scenarios."""
+        self.run_yaml_scenario("test_data_performance_obligation.yaml")


### PR DESCRIPTION
Closes #42

## Perubahan

* **`performance_obligation._get_analytic_parent_id()`** (baru) — mengembalikan
  `source_analytic_account_id.id`, atau `False` bila source kosong **atau** source
  sama dengan `analytic_account_id` milik PoB (guard anti self-parent; OCA
  `account_analytic_parent` melempar `UserError` untuk hierarki rekursif).
* **`parent_id` diisi di kedua jalur** — `_prepare_analytic_account()` (create) dan
  `_prepare_update_analytic_account()` (update). Jalur update menimpa tanpa syarat,
  sejalan dengan `name`/`code`/`group_id`, karena `source_analytic_account_id` adalah
  sumber kebenaran tunggal parent AA PoB.
* **`migrations/14.0.8.3.0/post-migrate.py`** (baru) — backfill `parent_id` untuk AA
  PoB yang sudah ada, lewat ORM (bukan SQL mentah) karena `complete_name` adalah
  stored compute dan `parent_path` dipelihara OCA `account_analytic_parent`.
  Idempoten & bersyarat: hanya PoB dengan `analytic_account_id` + `source_analytic_account_id`
  terisi, keduanya bukan record yang sama, dan `parent_id` belum menunjuk source.
* **`version` manifest** dinaikkan ke `14.0.8.3.0` mengikuti nama folder migrasi.
* **Unit test** (`tests/test_performance_obligation.py` + YAML): jalur create, jalur
  update, perpindahan `source_analytic_account_id`, dan guard self-parent.

Tidak ada field `parent_id` yang didefinisikan di modul ini (`account_analytic_parent`
sudah dependensi transitif lewat `ssi_cost_accounting`), `depends` tidak berubah, dan
perilaku `name`/`code`/`partner_id`/`group_id`/`date_start`/`date_end` tidak berubah.