### PR TITLE
[UPD] ssi_revenue_recognition_operating_unit - Lengkapi docstring class

### DIFF
--- a/ssi_revenue_recognition_operating_unit/models/performance_obligation.py
+++ b/ssi_revenue_recognition_operating_unit/models/performance_obligation.py
@@ -6,6 +6,19 @@ from odoo import fields, models
 
 
 class PerformanceObligation(models.Model):
+    """
+    Adds single operating unit support to Performance Obligation.
+
+    Unlike ``PerformanceObligationAcceptance`` and
+    ``RevenueRecognition`` below, ``operating_unit_id`` here is not a
+    ``related`` field and does not fall back to
+    ``mixin.single_operating_unit``'s default (the acting user's
+    operating unit). It is stamped at creation time by the
+    ``ssi_service_revenue_recognition_operating_unit`` bridge, copied
+    from the source service contract, and stays a plain, editable
+    field afterwards.
+    """
+
     _name = "performance_obligation"
     _inherit = [
         "performance_obligation",

--- a/ssi_revenue_recognition_operating_unit/models/performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition_operating_unit/models/performance_obligation_acceptance.py
@@ -6,6 +6,17 @@ from odoo import fields, models
 
 
 class PerformanceObligationAcceptance(models.Model):
+    """
+    Adds single operating unit support to Performance Obligation
+    Acceptance.
+
+    ``operating_unit_id`` is a stored ``related`` field that mirrors
+    ``performance_obligation_id.operating_unit_id``, so an acceptance
+    always carries its performance obligation's operating unit
+    instead of falling back to the acting user's default operating
+    unit.
+    """
+
     _name = "performance_obligation_acceptance"
     _inherit = [
         "performance_obligation_acceptance",

--- a/ssi_revenue_recognition_operating_unit/models/revenue_recognition.py
+++ b/ssi_revenue_recognition_operating_unit/models/revenue_recognition.py
@@ -6,6 +6,16 @@ from odoo import fields, models
 
 
 class RevenueRecognition(models.Model):
+    """
+    Adds single operating unit support to Revenue Recognition.
+
+    ``operating_unit_id`` is a stored ``related`` field that mirrors
+    ``performance_obligation_id.operating_unit_id``, keeping the
+    performance obligation, its acceptance, and this revenue
+    recognition record on the same operating unit instead of falling
+    back to the acting user's default operating unit.
+    """
+
     _name = "revenue_recognition"
     _inherit = [
         "revenue_recognition",


### PR DESCRIPTION
## Ringkasan

Menambahkan docstring class untuk `PerformanceObligation`,
`PerformanceObligationAcceptance`, dan `RevenueRecognition` di modul
`ssi_revenue_recognition_operating_unit`. Docstring menjelaskan apa yang
ditambahkan lapisan Operating Unit pada model yang di-inherit (propagasi
`operating_unit_id` ke dokumen turunan), bukan mengulang deskripsi model
dasar.

Item ini murni dokumentasi kode — tidak ada field, method, view, atau
manifest yang diubah.

## Verifikasi

```
verify-module.sh ssi_revenue_recognition_operating_unit 14.0 --strict
LOLOS: 0 ERROR, 0 peringatan, 0 tertunda.
```

```
pre-commit-gate.sh
GATE OK: 6 pemeriksaan, 0 pelanggaran baru.
```

Closes #46