### PR TITLE
[UPD] ssi_revenue_recognition_project - Lengkapi docstring

### DIFF
--- a/ssi_revenue_recognition_project/models/performance_obligation.py
+++ b/ssi_revenue_recognition_project/models/performance_obligation.py
@@ -8,6 +8,15 @@ from odoo.addons.ssi_decorator import ssi_decorator
 
 
 class PerformanceObligation(models.Model):
+    """
+    Adds optional ``project.project`` provisioning to Performance
+    Obligation (PoB).
+    When ``auto_create_project`` is enabled, opening the PoB creates
+    (or refreshes) a linked project so delivery work for that PoB can
+    be tracked in the Project app, without requiring a manual project
+    to be created and linked by hand.
+    """
+
     _name = "performance_obligation"
     _inherit = [
         "performance_obligation",
@@ -24,6 +33,18 @@ class PerformanceObligation(models.Model):
 
     @ssi_decorator.post_open_action()
     def _01_create_project(self):
+        """Provision the delivery project when the PoB is opened.
+
+        Runs after the Performance Obligation transitions to the
+        ``open`` state (``post_open_action`` hook). Does nothing when
+        ``auto_create_project`` is disabled.
+
+        Side effect: creates a ``project.project`` record from
+        ``_prepare_project_data`` and links it through ``project_id``
+        when the PoB has none yet; when a project is already linked,
+        that project is updated in place with the same values instead
+        of creating a duplicate.
+        """
         self.ensure_one()
         Project = self.env["project.project"]
 
@@ -37,6 +58,17 @@ class PerformanceObligation(models.Model):
             self.project_id.write(self._prepare_project_data())
 
     def _prepare_project_data(self):
+        """Build the ``project.project`` values for this PoB.
+
+        Extension point: override in a derived module to add or
+        change fields (e.g. ``..._project_operating_unit`` overrides
+        this to propagate the operating unit) without touching
+        ``_01_create_project``.
+
+        :return: dict of ``project.project`` values (``name``,
+            ``code``, ``analytic_account_id``, ``partner_id``,
+            ``date_start``, ``date``)
+        """
         self.ensure_one()
         return {
             "name": self.title,


### PR DESCRIPTION
## Ringkasan

Melengkapi docstring modul `ssi_revenue_recognition_project` di
`models/performance_obligation.py`, menutup temuan
`setiap-class-method-punya-docstring` dari sapuan `audit-sweep.sh 14.0`
(validator `module`, `--strict`).

- Docstring class `PerformanceObligation` — menjelaskan apa yang
  ditambahkan lapisan project pada `performance_obligation` dasar.
- Docstring `_01_create_project` — menyebut state pemicu
  (`post_open_action`) dan efek samping (membuat/menautkan
  `project.project`).
- Docstring `_prepare_project_data` — memuat `:return:` yang
  menyatakan isi dict nilai `project.project`, karena method ini
  titik override modul turunan.

Murni dokumentasi kode — tidak ada perubahan field, method, view,
atau manifest.

## Verifikasi

```
#VALIDATOR name=module target=ssi_revenue_recognition_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-revenue-recognition-47 modules=1 failed=0 skipped=0 status=OK
```

Closes #47