### PR TITLE
[UPD] ssi_revenue_recognition_project_operating_unit - Lengkapi docstring glue

### DIFF
--- a/ssi_revenue_recognition_project_operating_unit/models/performance_obligation.py
+++ b/ssi_revenue_recognition_project_operating_unit/models/performance_obligation.py
@@ -6,12 +6,29 @@ from odoo import models
 
 
 class PerformanceObligation(models.Model):
+    """
+    Bridges Performance Obligation (PoB), Project, and Operating Unit.
+    Glues ``ssi_revenue_recognition_project`` (project provisioning),
+    ``ssi_revenue_recognition_operating_unit`` (OU on the PoB), and
+    ``ssi_project_operating_unit`` (OU on ``project.project``) so the
+    OU on a PoB propagates to the project it auto-creates.
+    """
+
     _name = "performance_obligation"
     _inherit = [
         "performance_obligation",
     ]
 
     def _prepare_project_data(self):
+        """Add ``operating_unit_id`` to the project values.
+
+        Override that calls ``super()`` and then inserts the PoB's
+        ``operating_unit_id`` into the values, so the project created
+        (or updated) from this PoB carries the same Operating Unit.
+
+        :return: dict of ``project.project`` values, extended with
+            ``operating_unit_id``
+        """
         self.ensure_one()
         _super = super()
         result = _super._prepare_project_data()


### PR DESCRIPTION
## Ringkasan

Melengkapi docstring class `PerformanceObligation` dan method
`_prepare_project_data` di `ssi_revenue_recognition_project_operating_unit`
sesuai standar docstring SSI (`10-docstring.md`). Murni dokumentasi kode —
tidak ada perubahan field, method, view, atau manifest.

- Docstring class menjelaskan peran glue tiga arah: Performance Obligation
  x project x Operating Unit, menyebut ketiga modul yang dijembatani.
- Docstring `_prepare_project_data` menyatakan bahwa method ini override
  yang memanggil `super()`, menyisipkan `operating_unit_id`, dan
  mendokumentasikan nilai balik lewat `:return:`.

## Validasi

```
#VALIDATOR name=module target=.../ssi_revenue_recognition_project_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-revenue-recognition-48 modules=1 failed=0 skipped=0 status=OK
```

Closes #48