### PR TITLE
[UPD] ssi_performance_obligation_quality_control - lengkapi docstring

### DIFF
--- a/ssi_performance_obligation_quality_control/migrations/14.0.2.1.0/post-migrate.py
+++ b/ssi_performance_obligation_quality_control/migrations/14.0.2.1.0/post-migrate.py
@@ -10,20 +10,23 @@ _logger = logging.getLogger(__name__)
 
 
 def migrate(cr, version):
-    """Post-migration for ssi_performance_obligation_quality_control 14.0.2.1.0.
+    """Post-migration for ssi_performance_obligation_quality_control
+    14.0.2.1.0.
 
     Re-sync qc_worksheet.model_name with its model_id.
 
     qc_worksheet.model_name is a stored related on model_id.model. When the
-    performance obligation model was renamed (service_contract.performance_obligation
-    -> performance_obligation, by ssi_revenue_recognition migration 14.0.5.0.0),
-    openupgrade.rename_models updated ir_model and the well-known model-name columns
-    but did NOT recompute this arbitrary stored-related Char, so existing qc_worksheet
-    rows kept the old model name. The mixin.qc_worksheet One2many filters on
+    performance obligation model was renamed
+    (service_contract.performance_obligation -> performance_obligation, by
+    ssi_revenue_recognition migration 14.0.5.0.0), openupgrade.rename_models
+    updated ir_model and the well-known model-name columns but did NOT
+    recompute this arbitrary stored-related Char, so existing qc_worksheet rows
+    kept the old model name. The mixin.qc_worksheet One2many filters on
     model_name, so those worksheets silently detached from their performance
-    obligation. This realigns the stored column with the live ir_model name. It is
-    general (re-syncs ANY drifted model_name, not just the performance obligation
-    one) and idempotent (touches zero rows on an already-consistent database).
+    obligation. This realigns the stored column with the live ir_model name. It
+    is general (re-syncs ANY drifted model_name, not just the performance
+    obligation one) and idempotent (touches zero rows on an already-consistent
+    database).
     """
     _logger.info(
         "14.0.2.1.0 post-migrate: re-sync qc_worksheet.model_name from ir_model"

--- a/ssi_performance_obligation_quality_control/models/performance_obligation.py
+++ b/ssi_performance_obligation_quality_control/models/performance_obligation.py
@@ -6,6 +6,13 @@ from odoo import models
 
 
 class PerformanceObligation(models.Model):
+    """
+    Adds a quality control worksheet page to the performance obligation.
+    Lets QC staff record ``qc_worksheet`` results (automatic or manual)
+    against a PoB before its revenue is recognised, without changing any
+    of the base model's transaction states or fields.
+    """
+
     _name = "performance_obligation"
     _inherit = [
         "performance_obligation",


### PR DESCRIPTION
## Ringkasan

Melengkapi docstring modul `ssi_performance_obligation_quality_control` sesuai temuan `audit-sweep.sh 14.0 --repo ssi-revenue-recognition` (validator `module` v3.9.0, `--strict`):

1. Docstring class `PerformanceObligation` di `models/performance_obligation.py` — menjelaskan lapisan quality control (worksheet QC) yang ditambahkan modul ini di atas model `performance_obligation` dasar.
2. Docstring method `migrate` di `migrations/14.0.2.1.0/post-migrate.py` dibungkus ulang agar setiap baris ≤ 79 karakter — hanya pembungkusan baris, kalimat dan kode migrasi tidak berubah.

Tidak ada perubahan perilaku model maupun logika migrasi. `version` di `__manifest__.py` tidak dinaikkan (tidak ada direktori migrasi baru).

## Verifikasi

```
LOLOS: 0 ERROR, 0 peringatan, 0 tertunda.
#VALIDATOR name=module target=.../ssi_performance_obligation_quality_control series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

```
GATE OK: 6 pemeriksaan, 0 pelanggaran baru.
#GATE repo=ssi-revenue-recognition modules=1 failed=0 skipped=0 status=OK
```

Closes #50