### PR TITLE
[UPD] ssi_revenue_recognition - Instruksi Kerja & tour

### DIFF
--- a/ssi_revenue_recognition/README.rst
+++ b/ssi_revenue_recognition/README.rst
@@ -20,6 +20,14 @@ To install this module, you need to:
 5.  Search For *Revenue Recognition*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Revenue Recognition Type <docs/revenue_recognition_type/index.html>`_
+* `Performance Obligation <docs/performance_obligation/index.html>`_
+* `Performance Obligation Acceptance <docs/performance_obligation_acceptance/index.html>`_
+* `Revenue Recognition <docs/revenue_recognition/index.html>`_
+
 Credits
 =======
 

--- a/ssi_revenue_recognition/__manifest__.py
+++ b/ssi_revenue_recognition/__manifest__.py
@@ -17,6 +17,7 @@
         "ssi_analytic_budget",
         "ssi_product_usage_account_type",
         "base_automation",
+        "web_tour",
     ],
     "data": [
         "security/ir_module_category_data.xml",
@@ -41,6 +42,7 @@
         "views/performance_obligation_acceptance_views.xml",
         "views/performance_obligation_views.xml",
         "views/revenue_recognition_views.xml",
+        "views/assets.xml",
     ],
     "demo": [
         "demo/account_account_demo.xml",

--- a/ssi_revenue_recognition/data/ir_sequence_data.xml
+++ b/ssi_revenue_recognition/data/ir_sequence_data.xml
@@ -35,4 +35,15 @@
     <field name="use_date_range" eval="1" />
     <field eval="False" name="company_id" />
 </record>
+
+<!-- Revenue Recognition Type -->
+<record id="rrt_sequence" model="ir.sequence">
+    <field name="name">Revenue Recognition Type</field>
+    <field name="code">revenue_recognition_type</field>
+    <field name="prefix">RRT/</field>
+    <field eval="1" name="number_next" />
+    <field eval="1" name="number_increment" />
+    <field name="padding" eval="6" />
+    <field eval="False" name="company_id" />
+</record>
 </odoo>

--- a/ssi_revenue_recognition/data/sequence_template_data.xml
+++ b/ssi_revenue_recognition/data/sequence_template_data.xml
@@ -68,4 +68,23 @@
     <field name="add_custom_prefix" eval="0" />
     <field name="add_custom_suffix" eval="0" />
 </record>
+
+<!-- Revenue Recognition Type -->
+<record id="rrt_sequence_template" model="sequence.template">
+    <field name="name">Standard</field>
+    <field name="model_id" ref="model_revenue_recognition_type" />
+    <field name="sequence" eval="100" />
+    <field name="initial_string">/</field>
+    <field
+            name="sequence_field_id"
+            search="[('model_id.model','=','revenue_recognition_type'),('name','=','name')]"
+        />
+    <!-- Master data, no date field to range the sequence by. -->
+    <field name="computation_method">use_python</field>
+    <field name="python_code">result=True</field>
+    <field name="sequence_id" ref="rrt_sequence" />
+    <field name="sequence_selection_method">use_sequence</field>
+    <field name="add_custom_prefix" eval="0" />
+    <field name="add_custom_suffix" eval="0" />
+</record>
 </odoo>

--- a/ssi_revenue_recognition/data/sequence_template_data.xml
+++ b/ssi_revenue_recognition/data/sequence_template_data.xml
@@ -79,7 +79,13 @@
             name="sequence_field_id"
             search="[('model_id.model','=','revenue_recognition_type'),('name','=','name')]"
         />
-    <!-- Master data, no date field to range the sequence by. -->
+    <!-- Master data has no date field of its own; range by create_date,
+         matching the pattern used by other mixin.master_data sequences
+         (e.g. ssi_task_code, ssi_financial_budget). -->
+    <field
+            name="date_field_id"
+            search="[('model_id.model','=','revenue_recognition_type'),('name','=','create_date')]"
+        />
     <field name="computation_method">use_python</field>
     <field name="python_code">result=True</field>
     <field name="sequence_id" ref="rrt_sequence" />

--- a/ssi_revenue_recognition/docs/performance_obligation/01-create.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/01-create.md
@@ -1,0 +1,45 @@
+# Create Performance Obligation
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
+> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
+> group \_Performance Obligation — User* > **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Data:** A contract's `account.analytic.account` (the **Source Analytic Account**)
+  already exists — the Performance Obligation (PoB) will own an analytic account created
+  below it once the PoB is opened.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Config:** An active `sequence.template` exists for this model, used when the PoB
+  reaches **Open**.
+- **Access:** User is in group _Performance Obligation — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligations** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Source Analytic Account**: Select the contract's analytic account this PoB
+     belongs to.
+   - **Title**: Enter a title for the promised good or service. Automatically filled
+     from **Product**, if selected. Change if needed.
+   - **Revenue Recognition Timing**: Select **Over Time** or **At a Point in Time**.
+   - **Progress Completion Method**: Select **Input** or **Output**. Hidden when
+     **Revenue Recognition Timing** is **At a Point in Time**.
+   - **Date Start** / **Date End** _(required if **Revenue Recognition Timing** is **At
+     a Point in Time**)_: Only shown and required for that timing.
+4. On the **Transaction Price Allocation** tab, fill in:
+   - **Currency**: Select the currency used to price this PoB.
+   - **Product**: Select the promised good or service, if applicable.
+   - **UoM Quantity**: Enter the promised quantity.
+   - **UoM**: Automatically filled from **Product**. Change if needed.
+   - **Pricelist**: Select the pricelist used to derive the unit price, if applicable.
+   - **Price Unit**: Enter the unit price.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.

--- a/ssi_revenue_recognition/docs/performance_obligation/02-edit.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/02-edit.md
@@ -1,0 +1,22 @@
+# Edit Performance Obligation
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
+> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
+> group \_Performance Obligation — User* > **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Performance Obligation — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligations** menu.
+2. Find and open the record to edit.
+3. Click the **Edit** button.
+4. Change the required fields.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_revenue_recognition/docs/performance_obligation/03-delete.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Performance Obligation
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
+> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
+> group \_Performance Obligation — User* > **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Performance Obligation — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligations** menu.
+2. Open the record to delete.
+3. Open the **Action** menu.
+4. Click **Delete**.
+5. Click **OK** to confirm.
+
+## Post-Condition
+
+- The record is permanently removed from the system.

--- a/ssi_revenue_recognition/docs/performance_obligation/04-confirm.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/04-confirm.md
@@ -1,0 +1,27 @@
+# Confirm Performance Obligation
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
+> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
+> group \_Performance Obligation — User* > **State:** `draft` → `confirm` >
+> **Requires:** > `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Access:** User is in group _Performance Obligation — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligations** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the approval template.

--- a/ssi_revenue_recognition/docs/performance_obligation/05-approve.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/05-approve.md
@@ -1,0 +1,29 @@
+# Approve Performance Obligation
+
+> **Module:** ssi_revenue_recognition **Model:** `performance_obligation` > **Menu:**
+> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** approver on
+> the approval level that is currently pending **State:** `confirm` → `open` >
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. When the template uses sequential approval, only the first unapproved
+  level is pending.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligations** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+- If all approval levels are fulfilled, the record is automatically opened (method
+  `action_open`): status changes to **Open**, and the PoB's own analytic account is
+  created below **Source Analytic Account** (or resynced if it already exists).

--- a/ssi_revenue_recognition/docs/performance_obligation/06-reject.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/06-reject.md
@@ -1,0 +1,24 @@
+# Reject Performance Obligation
+
+> **Module:** ssi_revenue_recognition **Model:** `performance_obligation` > **Menu:**
+> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** approver on
+> the approval level that is currently pending **State:** `confirm` → `reject` >
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligations** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_revenue_recognition/docs/performance_obligation/09-auto-done.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/09-auto-done.md
@@ -1,0 +1,30 @@
+# Auto-Finish Performance Obligation
+
+> **Module:** ssi_revenue_recognition **Model:** `performance_obligation` > **Menu:**
+> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** System —
+> triggered automatically, no user interaction **State:** `open` → `done` >
+> **Requires:** `05-approve`
+
+There is no **Done** button on this model (`_automatically_insert_done_button = False`).
+The transition to **Done** is performed automatically by a `base.automation` rule
+(`pob_open_2_done`) whenever the PoB is written to and its computed **Quantity Diff.**
+reaches `0.0` while the record is **Open**.
+
+## Pre-Condition
+
+- **Record:** Status is **Open**.
+- **Record:** At least one **Performance Obligation Acceptance** for this PoB has
+  reached status **Done**, so **Quantity Accepted** can equal **UoM Quantity**.
+
+## Flow
+
+This transition has no click steps — it is triggered automatically by the system. A user
+records (and completes the approval of) a **Performance Obligation Acceptance** for this
+PoB whose accepted quantity brings the PoB's **Quantity Diff.** field down to `0.0` —
+see `docs/performance_obligation_acceptance/05-approve.md`. Writing the acceptance
+recomputes the PoB's stored **Quantity Diff.** field, which in turn re-evaluates the
+`base.automation` rule `pob_open_2_done`.
+
+## Post-Condition
+
+- Status changes to **Done**.

--- a/ssi_revenue_recognition/docs/performance_obligation/10-cancel.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/10-cancel.md
@@ -1,0 +1,27 @@
+# Cancel Performance Obligation
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
+> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
+> group \_Performance Obligation — User* > **State:** `draft` | `open` → `cancel` >
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft** or **Open**.
+- **Config:** An active `policy.template` grants `cancel_ok` for that state to the
+  actor's group.
+- **Data:** At least one `base.cancel_reason` is configured for this model.
+- **Access:** User is in group _Performance Obligation — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligations** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_revenue_recognition/docs/performance_obligation/12-restart.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/12-restart.md
@@ -1,0 +1,26 @@
+# Restart Performance Obligation
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
+> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
+> group \_Performance Obligation — Validator* > **State:** `cancel` | `reject` →
+> `draft` > **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` grants `restart_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _Performance Obligation — Validator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligations** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  starts the approval process from the beginning.

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/01-create.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/01-create.md
@@ -1,0 +1,43 @@
+# Create Performance Obligation Acceptance
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
+> **Actor:** user in group \_Performance Obligation Acceptance — User* > **State:** `—`
+> → `draft`
+
+## Pre-Condition
+
+- **Data:** A `performance_obligation` document exists in status **Open** (or **Done**)
+  for the customer, so it can be selected.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Config:** An active `sequence.template` exists for this model.
+- **Access:** User is in group _Performance Obligation Acceptance — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligation
+   Acceptances** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Partner**: Select the customer accepting the fulfilled quantity/progress.
+   - **Contact**: Select the contact person, if applicable.
+   - **# Performance Obligation**: Select the PoB (filtered to the selected **Partner**)
+     this acceptance is for.
+   - **Date**: Enter the acceptance date.
+   - **Date Start** / **Date End**: Enter the period covered by this acceptance.
+4. On the **Manual Fulfillments** tab, add lines when the PoB's **Fulfillment Field** is
+   configured to read manual entries. Repeat the following steps as many times as
+   needed:
+   - Click **Add a line**.
+   - Fill in each line with:
+     - **Product**: Select the product/service fulfilled, if applicable.
+     - **UoM Quantity**: Enter the fulfilled quantity.
+     - **UoM**: Automatically filled from **Product**. Change if needed.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/02-edit.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/02-edit.md
@@ -1,0 +1,24 @@
+# Edit Performance Obligation Acceptance
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
+> **Actor:** user in group \_Performance Obligation Acceptance — User* > **Requires:** >
+> `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Performance Obligation Acceptance — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligation
+   Acceptances** menu.
+2. Find and open the record to edit.
+3. Click the **Edit** button.
+4. Change the required fields.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/03-delete.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/03-delete.md
@@ -1,0 +1,25 @@
+# Delete Performance Obligation Acceptance
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
+> **Actor:** user in group \_Performance Obligation Acceptance — User* > **Requires:** >
+> `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Performance Obligation Acceptance — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligation
+   Acceptances** menu.
+2. Open the record to delete.
+3. Open the **Action** menu.
+4. Click **Delete**.
+5. Click **OK** to confirm.
+
+## Post-Condition
+
+- The record is permanently removed from the system.

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/04-confirm.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/04-confirm.md
@@ -1,0 +1,28 @@
+# Confirm Performance Obligation Acceptance
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
+> **Actor:** user in group \_Performance Obligation Acceptance — User* > **State:** >
+> `draft` → `confirm` > **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Access:** User is in group _Performance Obligation Acceptance — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligation
+   Acceptances** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the approval template.

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/05-approve.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/05-approve.md
@@ -1,0 +1,30 @@
+# Approve Performance Obligation Acceptance
+
+> **Module:** ssi_revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
+> **Actor:** approver on the approval level that is currently pending **State:** >
+> `confirm` → `done` > **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. When the template uses sequential approval, only the first unapproved
+  level is pending.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligation
+   Acceptances** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+- If all approval levels are fulfilled, the record is automatically finished (method
+  `action_done`): status changes to **Done**, and its fulfilled quantity becomes
+  eligible to be picked up by a `revenue_recognition` document.

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/06-reject.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/06-reject.md
@@ -1,0 +1,25 @@
+# Reject Performance Obligation Acceptance
+
+> **Module:** ssi_revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
+> **Actor:** approver on the approval level that is currently pending **State:** >
+> `confirm` → `reject` > **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligation
+   Acceptances** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/10-cancel.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/10-cancel.md
@@ -1,0 +1,28 @@
+# Cancel Performance Obligation Acceptance
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
+> **Actor:** user in group \_Performance Obligation Acceptance — Validator* >
+> **State:** > `draft` | `confirm` | `done` → `cancel` > **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Done**.
+- **Config:** An active `policy.template` grants `cancel_ok` for that state to the
+  actor's group.
+- **Data:** At least one `base.cancel_reason` is configured for this model.
+- **Access:** User is in group _Performance Obligation Acceptance — Validator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligation
+   Acceptances** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/12-restart.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/12-restart.md
@@ -1,0 +1,27 @@
+# Restart Performance Obligation Acceptance
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
+> **Actor:** user in group \_Performance Obligation Acceptance — Validator* >
+> **State:** > `cancel` | `reject` → `draft` > **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` grants `restart_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _Performance Obligation Acceptance — Validator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligation
+   Acceptances** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  starts the approval process from the beginning.

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/14-restart-approval.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/14-restart-approval.md
@@ -1,0 +1,27 @@
+# Restart Approval Process — Performance Obligation Acceptance
+
+> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
+> **Actor:** user in group \_Performance Obligation Acceptance — Validator* >
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `restart_approval_ok` for state
+  `confirm` to the actor's group.
+- **Access:** User is in group _Performance Obligation Acceptance — Validator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Performance Obligation
+   Acceptances** menu.
+2. Open the record whose approval process will be restarted.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- Existing approval records are discarded and recreated from the approval template, so
+  the approval process starts again from the first level.

--- a/ssi_revenue_recognition/docs/revenue_recognition/01-create.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/01-create.md
@@ -25,7 +25,12 @@
 
 1. Open the **Cost Accounting > Revenue Recognition > Revenue Recognitions** menu.
 2. Click the **New** button. **(14.0: "Create")**
-3. Fill in the required fields:
+3. Fill in the required fields, in this order — **Partner** and **# Performance
+   Obligation** first, so **Product** (via the selected PoB) is already known when
+   **Type** is filled in and its Unearned Income/Income Account lookup runs:
+   - **Partner**: Select the customer.
+   - **# Performance Obligation**: Select the PoB (filtered to the selected **Partner**)
+     this recognition is for.
    - **Type**: Select the `revenue_recognition_type` configuring the journal and account
      usages for this document.
    - **Journal**: Automatically filled from **Type**. Change if needed.
@@ -33,9 +38,6 @@
      (via the product's fiscal position). Change if needed.
    - **Income Account**: Automatically filled from **Type** and **Product**. Change if
      needed.
-   - **Partner**: Select the customer.
-   - **# Performance Obligation**: Select the PoB (filtered to the selected **Partner**)
-     this recognition is for.
    - **Date**: Enter the recognition date.
    - **Date Start** / **Date End**: Enter the period of WIP transactions to consider.
 4. On the **Accounting** tab, the **Account Mappings** grid is automatically rebuilt

--- a/ssi_revenue_recognition/docs/revenue_recognition/01-create.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/01-create.md
@@ -1,0 +1,54 @@
+# Create Revenue Recognition
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
+> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
+> \_Revenue Recognition — User* > **State:** `—` → `draft` > **Inline Actions:** >
+> `action_populate` (Populate)
+
+## Pre-Condition
+
+- **Data:** A `revenue_recognition_type` is configured with its journal and account
+  usages.
+- **Data:** A `performance_obligation` document exists in status **Open** (or **Done**)
+  for the customer, so it can be selected.
+- **Data:** At least one `performance_obligation_acceptance` for that PoB has reached
+  status **Done** and is not yet claimed by another Revenue Recognition document, so
+  **Populate** has something to pull in.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Config:** An active `sequence.template` exists for this model.
+- **Access:** User is in group _Revenue Recognition — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Revenue Recognitions** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Type**: Select the `revenue_recognition_type` configuring the journal and account
+     usages for this document.
+   - **Journal**: Automatically filled from **Type**. Change if needed.
+   - **Unearned Income Account**: Automatically filled from **Type** and **Product**
+     (via the product's fiscal position). Change if needed.
+   - **Income Account**: Automatically filled from **Type** and **Product**. Change if
+     needed.
+   - **Partner**: Select the customer.
+   - **# Performance Obligation**: Select the PoB (filtered to the selected **Partner**)
+     this recognition is for.
+   - **Date**: Enter the recognition date.
+   - **Date Start** / **Date End**: Enter the period of WIP transactions to consider.
+4. On the **Accounting** tab, the **Account Mappings** grid is automatically rebuilt
+   from **Type**'s configured WIP/expense account pairs whenever **Type** changes.
+5. Click **Populate** to link the unclaimed, **Done** Performance Obligation Acceptances
+   dated on or before **Date** to this record, and to refresh the WIP transactions dated
+   within **Date Start**/**Date End** used to compute each account mapping's balance and
+   budget. There is no manual way to fill these lists — **Populate** is the only way,
+   and running it again re-evaluates the same criteria (safe to repeat, e.g. after
+   changing **Date**). Skipping it leaves **Quantity Accepted**, **Amount Accepted**,
+   and the **Accounting** tab's balances at zero.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.

--- a/ssi_revenue_recognition/docs/revenue_recognition/02-edit.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/02-edit.md
@@ -1,0 +1,28 @@
+# Edit Revenue Recognition
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
+> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
+> \_Revenue Recognition — User* > **Requires:** `01-create` > **Inline Actions:** >
+> `action_populate` (Populate)
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Revenue Recognition — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Revenue Recognitions** menu.
+2. Find and open the record to edit.
+3. Click the **Edit** button.
+4. Change the required fields.
+5. Click **Populate** to refresh the linked Performance Obligation Acceptances and WIP
+   transactions — for example after changing **Date** or **Date Start**/**Date End**.
+   Running it again releases the previous claim and re-links acceptances/WIP
+   transactions against the new criteria; skipping it leaves the lists matching the old
+   dates.
+6. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_revenue_recognition/docs/revenue_recognition/03-delete.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Revenue Recognition
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
+> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
+> \_Revenue Recognition — User* > **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Revenue Recognition — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Revenue Recognitions** menu.
+2. Open the record to delete.
+3. Open the **Action** menu.
+4. Click **Delete**.
+5. Click **OK** to confirm.
+
+## Post-Condition
+
+- The record is permanently removed from the system.

--- a/ssi_revenue_recognition/docs/revenue_recognition/04-confirm.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/04-confirm.md
@@ -1,0 +1,27 @@
+# Confirm Revenue Recognition
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
+> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
+> \_Revenue Recognition — User* > **State:** `draft` → `confirm` > **Requires:** >
+> `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Access:** User is in group _Revenue Recognition — User_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Revenue Recognitions** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the approval template.

--- a/ssi_revenue_recognition/docs/revenue_recognition/05-approve.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/05-approve.md
@@ -1,0 +1,29 @@
+# Approve Revenue Recognition
+
+> **Module:** ssi_revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
+> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** approver on the
+> approval level that is currently pending **State:** `confirm` → `done` >
+> **Requires:** > `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. When the template uses sequential approval, only the first unapproved
+  level is pending.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Revenue Recognitions** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+- If all approval levels are fulfilled, the record is automatically finished (method
+  `action_done`): status changes to **Done**, and the accounting entry moving amounts
+  out of unearned income into income, WIP, and expense accounts is created and posted.

--- a/ssi_revenue_recognition/docs/revenue_recognition/06-reject.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/06-reject.md
@@ -1,0 +1,24 @@
+# Reject Revenue Recognition
+
+> **Module:** ssi_revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
+> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** approver on the
+> approval level that is currently pending **State:** `confirm` → `reject` >
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Revenue Recognitions** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_revenue_recognition/docs/revenue_recognition/10-cancel.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/10-cancel.md
@@ -1,0 +1,29 @@
+# Cancel Revenue Recognition
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
+> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
+> \_Revenue Recognition — Validator* > **State:** `draft` | `confirm` | `done` →
+> `cancel` > **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Done**.
+- **Config:** An active `policy.template` grants `cancel_ok` for that state to the
+  actor's group.
+- **Data:** At least one `base.cancel_reason` is configured for this model.
+- **Access:** User is in group _Revenue Recognition — Validator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Revenue Recognitions** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- If an accounting entry (**# Move**) had already been posted (i.e. the record was
+  **Done**), it is unposted, deleted, and the **# Move** field is cleared.

--- a/ssi_revenue_recognition/docs/revenue_recognition/12-restart.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/12-restart.md
@@ -1,0 +1,26 @@
+# Restart Revenue Recognition
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
+> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
+> \_Revenue Recognition — Validator* > **State:** `cancel` | `reject` → `draft` >
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` grants `restart_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _Revenue Recognition — Validator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Revenue Recognitions** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  starts the approval process from the beginning.

--- a/ssi_revenue_recognition/docs/revenue_recognition/14-restart-approval.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/14-restart-approval.md
@@ -1,0 +1,25 @@
+# Restart Approval Process — Revenue Recognition
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
+> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
+> \_Revenue Recognition — Validator* > **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `restart_approval_ok` for state
+  `confirm` to the actor's group.
+- **Access:** User is in group _Revenue Recognition — Validator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Revenue Recognition > Revenue Recognitions** menu.
+2. Open the record whose approval process will be restarted.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- Existing approval records are discarded and recreated from the approval template, so
+  the approval process starts again from the first level.

--- a/ssi_revenue_recognition/docs/revenue_recognition_type/01-create.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition_type/01-create.md
@@ -1,0 +1,42 @@
+# Create Revenue Recognition Type
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition_type` > **Menu:**
+> Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition Types
+> **Actor:** user in group \_Revenue Recognition Type — Configurator* > **State:** `—` →
+> `draft` > **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Data:** An `account.journal` exists to receive the accounting entries posted by
+  documents of this type.
+- **Data:** Two `product.usage_type` records exist — one to resolve the unearned income
+  account, one to resolve the income account.
+- **Access:** User is in group _Revenue Recognition Type — Configurator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Configuration > Revenue Recognition > Revenue
+   Recognition Types** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Name**: Enter a descriptive name for the type.
+   - **Code**: Leave as **/** to generate it automatically, or type a code manually.
+   - **Journal**: Select the journal used to post the accounting entry.
+   - **Unearned Income Usage**: Select the product usage code that resolves the unearned
+     income account.
+   - **Income Usage**: Select the product usage code that resolves the income account.
+4. On the **Accounting** tab, add one or more lines in **Account Mapping**. Repeat the
+   following steps as many times as needed:
+   - Click **Add a line**.
+   - Fill in each line with:
+     - **WIP Account**: Select the WIP account for this mapping.
+     - **Expense Account**: Select the expense account for this mapping.
+5. Click **Generate Code** to assign a document code from the sequence, if the **Code**
+   field is still **/**. You may also type a code manually instead. **Delete**
+   (03-delete) requires the code to still be **/**, so only generate/enter a permanent
+   code once the type is finalised.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new record is created and active.

--- a/ssi_revenue_recognition/docs/revenue_recognition_type/02-edit.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition_type/02-edit.md
@@ -1,0 +1,28 @@
+# Edit Revenue Recognition Type
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition_type` > **Menu:**
+> Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition Types
+> **Actor:** user in group \_Revenue Recognition Type — Configurator* > **Requires:** >
+> `01-create` > **Inline Actions:** `action_generate_code` (Generate Code)
+
+## Pre-Condition
+
+- **Record:** The record is active.
+- **Access:** User is in group _Revenue Recognition Type — Configurator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Configuration > Revenue Recognition > Revenue
+   Recognition Types** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. On the **Accounting** tab, add, edit, or remove lines in **Account Mapping** as
+   needed.
+5. Click **Generate Code** to assign a document code from the sequence — for example
+   after clearing the **Code** field back to **/**. You may also type a code manually
+   instead.
+6. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_revenue_recognition/docs/revenue_recognition_type/03-delete.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition_type/03-delete.md
@@ -1,0 +1,23 @@
+# Delete Revenue Recognition Type
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition_type` > **Menu:**
+> Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition Types
+> **Actor:** user in group \_Revenue Recognition Type — Configurator* > **Requires:** >
+> `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is not referenced by any `revenue_recognition` document.
+- **Access:** User is in group _Revenue Recognition Type — Configurator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Configuration > Revenue Recognition > Revenue
+   Recognition Types** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_revenue_recognition/docs/revenue_recognition_type/04-deactivate.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition_type/04-deactivate.md
@@ -1,0 +1,26 @@
+# Deactivate Revenue Recognition Type
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition_type` > **Menu:**
+> Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition Types
+> **Actor:** user in group \_Revenue Recognition Type — Configurator* > **Active:** >
+> `true` → `false` > **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** The record is currently active.
+- **Access:** User is in group _Revenue Recognition Type — Configurator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Configuration > Revenue Recognition > Revenue
+   Recognition Types** menu.
+2. Select one or more records to deactivate (check the checkbox).
+3. Click **Action** > **Archive**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The records are archived and no longer appear in the default list view.
+- Deactivated records cannot be selected as the **Type** of a new `revenue_recognition`
+  document.
+- `revenue_recognition` documents that already use this type can still be viewed.

--- a/ssi_revenue_recognition/docs/revenue_recognition_type/05-activate.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition_type/05-activate.md
@@ -1,0 +1,24 @@
+# Activate Revenue Recognition Type
+
+> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition_type` > **Menu:**
+> Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition Types
+> **Actor:** user in group \_Revenue Recognition Type — Configurator* > **Active:** >
+> `false` → `true` > **Requires:** `04-deactivate`
+
+## Pre-Condition
+
+- **Record:** The record is currently archived.
+- **Access:** User is in group _Revenue Recognition Type — Configurator_.
+
+## Flow
+
+1. Open the **Cost Accounting > Configuration > Revenue Recognition > Revenue
+   Recognition Types** menu.
+2. Enable the **Archived** filter in the search bar.
+3. Select one or more records to reactivate (check the checkbox).
+4. Click **Action** > **Unarchive**.
+
+## Post-Condition
+
+- The records are restored and appear again in the default list view.
+- The records can be selected as the **Type** of a new `revenue_recognition` document.

--- a/ssi_revenue_recognition/models/revenue_recognition_type.py
+++ b/ssi_revenue_recognition/models/revenue_recognition_type.py
@@ -17,6 +17,9 @@ class RevenueRecognitionType(models.Model):
     _inherit = ["mixin.master_data"]
     _description = "Revenue Recognition Type"
 
+    code = fields.Char(
+        default="/",
+    )
     journal_id = fields.Many2one(
         string="Journal",
         comodel_name="account.journal",

--- a/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -215,12 +215,28 @@ odoo.define("ssi_revenue_recognition.performance_obligation_acceptance_tour", fu
                 },
             },
 
-            // Flow 5 — Click OK to confirm. Odoo returns straight to the
-            // list after a successful delete (no back button to click).
+            // Flow 5 — Click OK to confirm.
             {
                 content: "Confirm deletion",
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
+            },
+            // Odoo sometimes leaves a clickable back button on the
+            // breadcrumb after a delete, and sometimes returns straight
+            // to the list on its own. Click the back button only if one
+            // is actually there.
+            {
+                content: "Return to the list",
+                trigger:
+                    ".breadcrumb-item.o_back_button a:contains(Performance Obligation Acceptances), .o_list_view:not(:has(.o_data_row:contains(POA-TOUR-DELETE)))",
+                run: function () {
+                    var $back = $(
+                        ".breadcrumb-item.o_back_button a:contains(Performance Obligation Acceptances)"
+                    );
+                    if ($back.length) {
+                        $back[0].click();
+                    }
+                },
             },
 
             // Post-Condition — The record is permanently removed.

--- a/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -215,16 +215,12 @@ odoo.define("ssi_revenue_recognition.performance_obligation_acceptance_tour", fu
                 },
             },
 
-            // Flow 5 — Click OK to confirm.
+            // Flow 5 — Click OK to confirm. Odoo returns straight to the
+            // list after a successful delete (no back button to click).
             {
                 content: "Confirm deletion",
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
-            },
-            {
-                content: "Back to the list",
-                trigger:
-                    ".breadcrumb-item.o_back_button a:contains(Performance Obligation Acceptances)",
             },
 
             // Post-Condition — The record is permanently removed.

--- a/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -182,10 +182,14 @@ odoo.define("ssi_revenue_recognition.performance_obligation_acceptance_tour", fu
         "ssi_revenue_recognition_performance_obligation_acceptance_delete",
         {test: true, url: "/web"},
         [].concat(openMenuSteps(), [
-            // Flow 2 — Open the record to delete.
+            // Flow 2 — Open the record to delete. Identified by its
+            // dedicated Partner, not by "# Document": `unlink()` requires
+            // the document number to still be "/" (`setUpClass`), so it
+            // cannot double as this row's identifying text.
             {
                 content: "Open the record",
-                trigger: ".o_data_row:contains(POA-TOUR-DELETE) .o_data_cell:first",
+                trigger:
+                    ".o_data_row:contains(TOUR-POBA-DELETE-PARTNER) .o_data_cell:first",
                 extra_trigger: ".o_list_view",
             },
             {
@@ -235,7 +239,7 @@ odoo.define("ssi_revenue_recognition.performance_obligation_acceptance_tour", fu
             {
                 content: "The record no longer appears in the list",
                 trigger:
-                    ".o_list_view:not(:has(.o_data_row:contains(POA-TOUR-DELETE)))",
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR-POBA-DELETE-PARTNER)))",
                 run: function () {
                     // Assertion only.
                 },

--- a/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -1,0 +1,491 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_revenue_recognition.performance_obligation_acceptance_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Flow 1 of every tour below — Open the Cost Accounting > Revenue
+    // Recognition > Performance Obligation Acceptances menu.
+    var openMenuSteps = function () {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Revenue Recognition menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+            },
+            {
+                content: "Open the Performance Obligation Acceptances menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_acceptance_menu"]',
+            },
+            {
+                content: "Performance Obligation Acceptances list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Performance Obligation Acceptances)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ];
+    };
+
+    // IK: docs/performance_obligation_acceptance/01-create.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_acceptance_create",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields.
+            {
+                content: "Select the Partner",
+                trigger: ".o_field_many2one[name='partner_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-POBA-PARTNER",
+            },
+            {
+                content: "Pick the Partner from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-POBA-PARTNER)",
+                in_modal: false,
+            },
+            {
+                content: "Select the # Performance Obligation",
+                trigger: ".o_field_many2one[name='performance_obligation_id'] input",
+                run: "text PB-TOUR-POBA-1",
+            },
+            {
+                content: "Pick the PoB from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(PB-TOUR-POBA-1)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in the Date",
+                trigger: ".o_field_widget[name='date'] input",
+                run: "text 01/15/2026",
+            },
+            {
+                content: "Fill in Date Start",
+                trigger: ".o_field_widget[name='date_start'] input",
+                run: "text 01/01/2026",
+            },
+            {
+                content: "Fill in Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                run: "text 01/31/2026",
+            },
+
+            // Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Post-Condition — A new record is created in Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation_acceptance/02-edit.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_acceptance_edit",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(POA-TOUR-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Edit button.
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 4 — Change the required fields.
+            {
+                content: "Change the Date",
+                trigger: ".o_field_widget[name='date'] input",
+                run: "text 01/20/2026",
+            },
+
+            // Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — The record is updated.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation_acceptance/03-delete.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_acceptance_delete",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Open the record to delete.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(POA-TOUR-DELETE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Open the Action menu.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+
+            // Flow 4 — Click Delete.
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+
+            // Flow 5 — Click OK to confirm.
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Back to the list",
+                trigger:
+                    ".breadcrumb-item.o_back_button a:contains(Performance Obligation Acceptances)",
+            },
+
+            // Post-Condition — The record is permanently removed.
+            {
+                content: "The record no longer appears in the list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(POA-TOUR-DELETE)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation_acceptance/04-confirm.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_acceptance_confirm",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(POA-TOUR-CONFIRM) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Confirm button",
+                trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                extra_trigger: ".o_form_view",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Status is Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation_acceptance/05-approve.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_acceptance_approve",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(POA-TOUR-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            // The single approval level is fulfilled, so the
+            // record is auto-finished (action_done).
+            {
+                content: "Status is Done",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation_acceptance/06-reject.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_acceptance_reject",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(POA-TOUR-REJECT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Reject button",
+                trigger: ".o_statusbar_buttons button[name='action_reject_approval']",
+                extra_trigger: ".o_form_view",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Status is Rejected",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='reject'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation_acceptance/10-cancel.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_acceptance_cancel",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(POA-TOUR-CANCEL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Cancel button",
+                trigger: ".o_statusbar_buttons button:enabled:contains('Cancel')",
+            },
+            {
+                content: "Wizard is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Select the Cancellation Reason",
+                trigger:
+                    ".o_field_widget[name='cancel_reason_id'] .o_radio_item:has(label:contains(TOUR Cancel Reason)) input.o_radio_input",
+                run: "click",
+            },
+            {
+                content: "Confirm the wizard",
+                trigger: ".modal-footer button[name='action_confirm']",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Status is Cancelled",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='cancel'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation_acceptance/12-restart.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_acceptance_restart",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(POA-TOUR-RESTART) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Restart button",
+                trigger: ".o_statusbar_buttons button[name='action_restart']",
+                extra_trigger: ".o_form_view",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation_acceptance/14-restart-approval.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_acceptance_restart_approval",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Open the record whose approval process will
+            // be restarted.
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(POA-TOUR-RESTARTAPPROVAL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Restart Approval Process button.
+            {
+                content: "Click the Restart Approval Process button",
+                trigger:
+                    ".o_statusbar_buttons button[name='action_reload_approval_template']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — Status remains Waiting for Approval.
+            {
+                content: "Status is still Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -221,22 +221,14 @@ odoo.define("ssi_revenue_recognition.performance_obligation_acceptance_tour", fu
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
             },
-            // Odoo sometimes leaves a clickable back button on the
-            // breadcrumb after a delete, and sometimes returns straight
-            // to the list on its own. Click the back button only if one
-            // is actually there.
+            // After delete, 14.0 can show the NEXT record in the list's
+            // recordset instead of returning to the list on its own — the
+            // breadcrumb still names the action either way, so click it
+            // unconditionally to get back to the list.
             {
-                content: "Return to the list",
+                content: "Click the Performance Obligation Acceptances breadcrumb",
                 trigger:
-                    ".breadcrumb-item.o_back_button a:contains(Performance Obligation Acceptances), .o_list_view:not(:has(.o_data_row:contains(POA-TOUR-DELETE)))",
-                run: function () {
-                    var $back = $(
-                        ".breadcrumb-item.o_back_button a:contains(Performance Obligation Acceptances)"
-                    );
-                    if ($back.length) {
-                        $back[0].click();
-                    }
-                },
+                    ".breadcrumb-item.o_back_button a:contains(Performance Obligation Acceptances)",
             },
 
             // Post-Condition — The record is permanently removed.

--- a/ssi_revenue_recognition/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/performance_obligation_tour.js
@@ -210,12 +210,28 @@ odoo.define("ssi_revenue_recognition.performance_obligation_tour", function (req
                 },
             },
 
-            // Flow 5 — Click OK to confirm. Odoo returns straight to the
-            // list after a successful delete (no back button to click).
+            // Flow 5 — Click OK to confirm.
             {
                 content: "Confirm deletion",
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
+            },
+            // Odoo sometimes leaves a clickable back button on the
+            // breadcrumb after a delete, and sometimes returns straight
+            // to the list on its own. Click the back button only if one
+            // is actually there.
+            {
+                content: "Return to the list",
+                trigger:
+                    ".breadcrumb-item.o_back_button a:contains(Performance Obligations), .o_list_view:not(:has(.o_data_row:contains(TOUR-POB-DELETE)))",
+                run: function () {
+                    var $back = $(
+                        ".breadcrumb-item.o_back_button a:contains(Performance Obligations)"
+                    );
+                    if ($back.length) {
+                        $back[0].click();
+                    }
+                },
             },
 
             // Post-Condition — The record is permanently removed.

--- a/ssi_revenue_recognition/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/performance_obligation_tour.js
@@ -83,7 +83,7 @@ odoo.define("ssi_revenue_recognition.performance_obligation_tour", function (req
             },
             {
                 content: "Fill in the Price Unit",
-                trigger: ".o_field_widget[name='price_unit']",
+                trigger: ".o_field_widget[name='price_unit'] input",
                 run: "text 100.00",
             },
 
@@ -147,7 +147,7 @@ odoo.define("ssi_revenue_recognition.performance_obligation_tour", function (req
             {
                 content: "Change the Title",
                 trigger: ".o_field_widget[name='title']",
-                run: "text TOUR-POB-EDIT (updated)",
+                run: "text TOUR-POB-EDIT-UPDATED",
             },
 
             // Flow 5 — Click Save.
@@ -164,7 +164,7 @@ odoo.define("ssi_revenue_recognition.performance_obligation_tour", function (req
             },
             {
                 content: "The updated title is shown in the list",
-                trigger: ".o_data_row:contains(TOUR-POB-EDIT (updated))",
+                trigger: ".o_data_row:contains(TOUR-POB-EDIT-UPDATED)",
                 run: function () {
                     // Assertion only.
                 },
@@ -210,16 +210,12 @@ odoo.define("ssi_revenue_recognition.performance_obligation_tour", function (req
                 },
             },
 
-            // Flow 5 — Click OK to confirm.
+            // Flow 5 — Click OK to confirm. Odoo returns straight to the
+            // list after a successful delete (no back button to click).
             {
                 content: "Confirm deletion",
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
-            },
-            {
-                content: "Back to the list",
-                trigger:
-                    ".breadcrumb-item.o_back_button a:contains(Performance Obligations)",
             },
 
             // Post-Condition — The record is permanently removed.

--- a/ssi_revenue_recognition/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/performance_obligation_tour.js
@@ -1,0 +1,477 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_revenue_recognition.performance_obligation_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Flow 1 of every tour below — Open the Cost Accounting > Revenue
+    // Recognition > Performance Obligations menu.
+    var openMenuSteps = function () {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Revenue Recognition menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+            },
+            {
+                content: "Open the Performance Obligations menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_menu"]',
+            },
+            {
+                content: "Performance Obligations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Performance Obligations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ];
+    };
+
+    // IK: docs/performance_obligation/01-create.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_create",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields.
+            {
+                content: "Fill in the Title",
+                trigger: ".o_field_widget[name='title']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-POB-CREATE",
+            },
+            {
+                content: "Select the Source Analytic Account",
+                trigger: ".o_field_many2one[name='source_analytic_account_id'] input",
+                run: "text TOUR-POB-SOURCE-AA",
+            },
+            {
+                content: "Pick the Source Analytic Account from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(TOUR-POB-SOURCE-AA)",
+                in_modal: false,
+            },
+
+            // Flow 4 — Transaction Price Allocation tab.
+            {
+                content: "Open the Transaction Price Allocation tab",
+                trigger: ".o_notebook .nav-link:contains(Transaction Price Allocation)",
+            },
+            {
+                content: "Fill in the Price Unit",
+                trigger: ".o_field_widget[name='price_unit']",
+                run: "text 100.00",
+            },
+
+            // Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Post-Condition — A new record is created in Draft status.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation/02-edit.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_edit",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-POB-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Edit button.
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 4 — Change the required fields.
+            {
+                content: "Change the Title",
+                trigger: ".o_field_widget[name='title']",
+                run: "text TOUR-POB-EDIT (updated)",
+            },
+
+            // Flow 5 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — The record is updated with the new values.
+            {
+                content: "Go back to the list",
+                trigger:
+                    ".breadcrumb-item:not(.active):contains(Performance Obligations)",
+            },
+            {
+                content: "The updated title is shown in the list",
+                trigger: ".o_data_row:contains(TOUR-POB-EDIT (updated))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation/03-delete.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_delete",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Open the record to delete.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-POB-DELETE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Open the Action menu.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+
+            // Flow 4 — Click Delete.
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+
+            // Flow 5 — Click OK to confirm.
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Back to the list",
+                trigger:
+                    ".breadcrumb-item.o_back_button a:contains(Performance Obligations)",
+            },
+
+            // Post-Condition — The record is permanently removed.
+            {
+                content: "The record no longer appears in the list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR-POB-DELETE)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation/04-confirm.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_confirm",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Open the record to confirm.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-POB-CONFIRM) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Confirm button.
+            {
+                content: "Click the Confirm button",
+                trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — Status changes to Waiting for Approval.
+            {
+                content: "Status is Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation/05-approve.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_approve",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Open the record to approve.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-POB-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — the single approval level is fulfilled,
+            // so the record is auto-opened (action_open).
+            {
+                content: "Status is Open",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation/06-reject.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_reject",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Open the record to reject.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-POB-REJECT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Reject button.
+            {
+                content: "Click the Reject button",
+                trigger: ".o_statusbar_buttons button[name='action_reject_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — Status changes to Rejected.
+            {
+                content: "Status is Rejected",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='reject'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation/10-cancel.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_cancel",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Open the record to cancel.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-POB-CANCEL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Cancel button (type="action").
+            {
+                content: "Click the Cancel button",
+                trigger: ".o_statusbar_buttons button:enabled:contains('Cancel')",
+            },
+            {
+                content: "Wizard is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 4 — Select the Reason.
+            {
+                content: "Select the Cancellation Reason",
+                trigger:
+                    ".o_field_widget[name='cancel_reason_id'] .o_radio_item:has(label:contains(TOUR Cancel Reason)) input.o_radio_input",
+                run: "click",
+            },
+
+            // Flow 5 — Click Confirm.
+            {
+                content: "Confirm the wizard",
+                trigger: ".modal-footer button[name='action_confirm']",
+            },
+
+            // Flow 6 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — Status changes to Cancelled.
+            {
+                content: "Status is Cancelled",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='cancel'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/performance_obligation/12-restart.md
+    tour.register(
+        "ssi_revenue_recognition_performance_obligation_restart",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Open the record to restart.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-POB-RESTART) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Restart button.
+            {
+                content: "Click the Restart button",
+                trigger: ".o_statusbar_buttons button[name='action_restart']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Flow 4 — Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — Status returns to Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_revenue_recognition/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/performance_obligation_tour.js
@@ -216,22 +216,14 @@ odoo.define("ssi_revenue_recognition.performance_obligation_tour", function (req
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
             },
-            // Odoo sometimes leaves a clickable back button on the
-            // breadcrumb after a delete, and sometimes returns straight
-            // to the list on its own. Click the back button only if one
-            // is actually there.
+            // After delete, 14.0 can show the NEXT record in the list's
+            // recordset instead of returning to the list on its own — the
+            // breadcrumb still names the action either way, so click it
+            // unconditionally to get back to the list.
             {
-                content: "Return to the list",
+                content: "Click the Performance Obligations breadcrumb",
                 trigger:
-                    ".breadcrumb-item.o_back_button a:contains(Performance Obligations), .o_list_view:not(:has(.o_data_row:contains(TOUR-POB-DELETE)))",
-                run: function () {
-                    var $back = $(
-                        ".breadcrumb-item.o_back_button a:contains(Performance Obligations)"
-                    );
-                    if ($back.length) {
-                        $back[0].click();
-                    }
-                },
+                    ".breadcrumb-item.o_back_button a:contains(Performance Obligations)",
             },
 
             // Post-Condition — The record is permanently removed.

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
@@ -57,11 +57,34 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 },
             },
 
-            // Flow 3 — Fill in the required fields.
+            // Flow 3 — Fill in the required fields. Partner and # Performance
+            // Obligation are selected before Type so that `product_id`
+            // (related through the PoB) is already resolved when Type's
+            // onchange looks up the Unearned Income/Income Account.
+            {
+                content: "Select the Partner",
+                trigger: ".o_field_many2one[name='partner_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-RR-PARTNER",
+            },
+            {
+                content: "Pick the Partner from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-RR-PARTNER)",
+                in_modal: false,
+            },
+            {
+                content: "Select the # Performance Obligation",
+                trigger: ".o_field_many2one[name='performance_obligation_id'] input",
+                run: "text PB-TOUR-RR-1",
+            },
+            {
+                content: "Pick the PoB from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(PB-TOUR-RR-1)",
+                in_modal: false,
+            },
             {
                 content: "Select the Type",
                 trigger: ".o_field_many2one[name='type_id'] input",
-                extra_trigger: ".o_form_view.o_form_editable",
                 run: "text TOUR-RR-TYPE",
             },
             {
@@ -78,7 +101,7 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
             },
             {
                 content:
-                    "Fill in the Unearned Income Account (no Product is set, so it was not auto-resolved)",
+                    "Fill in the Unearned Income Account (no account mapping is configured for the product, so it was not auto-resolved)",
                 trigger: ".o_field_many2one[name='unearned_income_account_id'] input",
                 run: "text TOUR RR Unearned Income Account",
             },
@@ -90,7 +113,7 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
             },
             {
                 content:
-                    "Fill in the Income Account (no Product is set, so it was not auto-resolved)",
+                    "Fill in the Income Account (no account mapping is configured for the product, so it was not auto-resolved)",
                 trigger: ".o_field_many2one[name='income_account_id'] input",
                 run: "text TOUR RR Income Account",
             },
@@ -98,26 +121,6 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 content: "Pick the Income Account from the dropdown",
                 trigger:
                     ".ui-autocomplete .ui-menu-item a:contains(TOUR RR Income Account)",
-                in_modal: false,
-            },
-            {
-                content: "Select the Partner",
-                trigger: ".o_field_many2one[name='partner_id'] input",
-                run: "text TOUR-RR-PARTNER",
-            },
-            {
-                content: "Pick the Partner from the dropdown",
-                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-RR-PARTNER)",
-                in_modal: false,
-            },
-            {
-                content: "Select the # Performance Obligation",
-                trigger: ".o_field_many2one[name='performance_obligation_id'] input",
-                run: "text PB-TOUR-RR-1",
-            },
-            {
-                content: "Pick the PoB from the dropdown",
-                trigger: ".ui-autocomplete .ui-menu-item a:contains(PB-TOUR-RR-1)",
                 in_modal: false,
             },
             {
@@ -267,8 +270,23 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
             },
-            // Odoo returns straight to the list after a successful
-            // delete (no back button to click).
+            // Odoo sometimes leaves a clickable back button on the
+            // breadcrumb after a delete, and sometimes returns straight
+            // to the list on its own. Click the back button only if one
+            // is actually there.
+            {
+                content: "Return to the list",
+                trigger:
+                    ".breadcrumb-item.o_back_button a:contains(Revenue Recognitions), .o_list_view:not(:has(.o_data_row:contains(RR-TOUR-DELETE)))",
+                run: function () {
+                    var $back = $(
+                        ".breadcrumb-item.o_back_button a:contains(Revenue Recognitions)"
+                    );
+                    if ($back.length) {
+                        $back[0].click();
+                    }
+                },
+            },
             {
                 content: "The record no longer appears in the list",
                 trigger: ".o_list_view:not(:has(.o_data_row:contains(RR-TOUR-DELETE)))",

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
@@ -82,6 +82,20 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 trigger: ".ui-autocomplete .ui-menu-item a:contains(PB-TOUR-RR-1)",
                 in_modal: false,
             },
+            // Selecting the PoB triggers a server round trip to recompute
+            // the related `product_id` (and other fields). Wait for the
+            // widget to show the committed value before touching Type —
+            // otherwise that still-in-flight onchange can re-render the
+            // form while Type's own dropdown pick is in progress (Odoo 14
+            // "onchange destroys the open autocomplete dropdown" race).
+            {
+                content: "Performance Obligation is committed",
+                trigger:
+                    ".o_field_many2one[name='performance_obligation_id'] input[value='PB-TOUR-RR-1']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
             {
                 content: "Select the Type",
                 trigger: ".o_field_many2one[name='type_id'] input",
@@ -144,6 +158,17 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 content: "Click Populate",
                 trigger: "button[name='action_populate']:enabled",
                 extra_trigger: ".o_form_view.o_form_editable",
+            },
+            // `action_populate` is a `type="object"` button: 14.0 disables
+            // it synchronously on click and only re-enables it once its
+            // full RPC + re-render cycle is done. Waiting for it to become
+            // `:enabled` again avoids Save racing that cycle.
+            {
+                content: "Populate finished",
+                trigger: "button[name='action_populate']:enabled",
+                run: function () {
+                    // Assertion only.
+                },
             },
 
             // Flow 6 — Click Save.
@@ -215,6 +240,17 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 trigger: "button[name='action_populate']:enabled",
                 extra_trigger: ".o_form_view.o_form_editable",
             },
+            // `action_populate` is a `type="object"` button: 14.0 disables
+            // it synchronously on click and only re-enables it once its
+            // full RPC + re-render cycle is done. Waiting for it to become
+            // `:enabled` again avoids Save racing that cycle.
+            {
+                content: "Populate finished",
+                trigger: "button[name='action_populate']:enabled",
+                run: function () {
+                    // Assertion only.
+                },
+            },
 
             // Flow 6 — Click Save.
             {
@@ -270,22 +306,14 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
             },
-            // Odoo sometimes leaves a clickable back button on the
-            // breadcrumb after a delete, and sometimes returns straight
-            // to the list on its own. Click the back button only if one
-            // is actually there.
+            // After delete, 14.0 can show the NEXT record in the list's
+            // recordset instead of returning to the list on its own — the
+            // breadcrumb still names the action either way, so click it
+            // unconditionally to get back to the list.
             {
-                content: "Return to the list",
+                content: "Click the Revenue Recognitions breadcrumb",
                 trigger:
-                    ".breadcrumb-item.o_back_button a:contains(Revenue Recognitions), .o_list_view:not(:has(.o_data_row:contains(RR-TOUR-DELETE)))",
-                run: function () {
-                    var $back = $(
-                        ".breadcrumb-item.o_back_button a:contains(Revenue Recognitions)"
-                    );
-                    if ($back.length) {
-                        $back[0].click();
-                    }
-                },
+                    ".breadcrumb-item.o_back_button a:contains(Revenue Recognitions)",
             },
             {
                 content: "The record no longer appears in the list",

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
@@ -72,6 +72,21 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-RR-PARTNER)",
                 in_modal: false,
             },
+            // Picking the Partner triggers `onchange_performance_obligation_id`
+            // (it unconditionally resets `performance_obligation_id`, in case
+            // a PoB from a previous partner was selected). Wait for that
+            // round trip to land before touching `# Performance Obligation` —
+            // otherwise the late-arriving onchange response can wipe out the
+            // PoB this tour is about to pick, since it is applied on top of
+            // whatever the widget shows at that later moment.
+            {
+                content: "Partner is committed",
+                trigger:
+                    ".o_field_many2one[name='partner_id'] input[value='TOUR-RR-PARTNER']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
             {
                 content: "Select the # Performance Obligation",
                 trigger: ".o_field_many2one[name='performance_obligation_id'] input",
@@ -274,9 +289,14 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
         "ssi_revenue_recognition_revenue_recognition_delete",
         {test: true, url: "/web"},
         [].concat(openMenuSteps(), [
+            // Identified by its dedicated Partner, not by "# Document":
+            // `unlink()` requires the document number to still be "/"
+            // (`setUpClass`), so it cannot double as this row's
+            // identifying text.
             {
                 content: "Open the record",
-                trigger: ".o_data_row:contains(RR-TOUR-DELETE) .o_data_cell:first",
+                trigger:
+                    ".o_data_row:contains(TOUR-RR-DELETE-PARTNER) .o_data_cell:first",
                 extra_trigger: ".o_list_view",
             },
             {
@@ -317,7 +337,8 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
             },
             {
                 content: "The record no longer appears in the list",
-                trigger: ".o_list_view:not(:has(.o_data_row:contains(RR-TOUR-DELETE)))",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR-RR-DELETE-PARTNER)))",
                 run: function () {
                     // Assertion only.
                 },

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
@@ -72,21 +72,6 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-RR-PARTNER)",
                 in_modal: false,
             },
-            // Picking the Partner triggers `onchange_performance_obligation_id`
-            // (it unconditionally resets `performance_obligation_id`, in case
-            // a PoB from a previous partner was selected). Wait for that
-            // round trip to land before touching `# Performance Obligation` —
-            // otherwise the late-arriving onchange response can wipe out the
-            // PoB this tour is about to pick, since it is applied on top of
-            // whatever the widget shows at that later moment.
-            {
-                content: "Partner is committed",
-                trigger:
-                    ".o_field_many2one[name='partner_id'] input[value='TOUR-RR-PARTNER']",
-                run: function () {
-                    // Assertion only.
-                },
-            },
             {
                 content: "Select the # Performance Obligation",
                 trigger: ".o_field_many2one[name='performance_obligation_id'] input",
@@ -97,20 +82,6 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 trigger: ".ui-autocomplete .ui-menu-item a:contains(PB-TOUR-RR-1)",
                 in_modal: false,
             },
-            // Selecting the PoB triggers a server round trip to recompute
-            // the related `product_id` (and other fields). Wait for the
-            // widget to show the committed value before touching Type —
-            // otherwise that still-in-flight onchange can re-render the
-            // form while Type's own dropdown pick is in progress (Odoo 14
-            // "onchange destroys the open autocomplete dropdown" race).
-            {
-                content: "Performance Obligation is committed",
-                trigger:
-                    ".o_field_many2one[name='performance_obligation_id'] input[value='PB-TOUR-RR-1']",
-                run: function () {
-                    // Assertion only.
-                },
-            },
             {
                 content: "Select the Type",
                 trigger: ".o_field_many2one[name='type_id'] input",
@@ -120,13 +91,6 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 content: "Pick the Type from the dropdown",
                 trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-RR-TYPE)",
                 in_modal: false,
-            },
-            {
-                content: "Journal is auto-filled from Type",
-                trigger: ".o_field_many2one[name='journal_id'] input[value!='']",
-                run: function () {
-                    // Assertion only.
-                },
             },
             {
                 content:

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
@@ -1,0 +1,527 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Flow 1 of every tour below — Open the Cost Accounting > Revenue
+    // Recognition > Revenue Recognitions menu.
+    var openMenuSteps = function () {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Revenue Recognition menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+            },
+            {
+                content: "Open the Revenue Recognitions menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.revenue_recognition_menu"]',
+            },
+            {
+                content: "Revenue Recognitions list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Revenue Recognitions)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ];
+    };
+
+    // IK: docs/revenue_recognition/01-create.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_create",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields.
+            {
+                content: "Select the Type",
+                trigger: ".o_field_many2one[name='type_id'] input",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-RR-TYPE",
+            },
+            {
+                content: "Pick the Type from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-RR-TYPE)",
+                in_modal: false,
+            },
+            {
+                content: "Journal is auto-filled from Type",
+                trigger: ".o_field_many2one[name='journal_id'] input[value!='']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content:
+                    "Fill in the Unearned Income Account (no Product is set, so it was not auto-resolved)",
+                trigger: ".o_field_many2one[name='unearned_income_account_id'] input",
+                run: "text TOUR RR Unearned Income Account",
+            },
+            {
+                content: "Pick the Unearned Income Account from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(TOUR RR Unearned Income Account)",
+                in_modal: false,
+            },
+            {
+                content:
+                    "Fill in the Income Account (no Product is set, so it was not auto-resolved)",
+                trigger: ".o_field_many2one[name='income_account_id'] input",
+                run: "text TOUR RR Income Account",
+            },
+            {
+                content: "Pick the Income Account from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(TOUR RR Income Account)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Partner",
+                trigger: ".o_field_many2one[name='partner_id'] input",
+                run: "text TOUR-RR-PARTNER",
+            },
+            {
+                content: "Pick the Partner from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-RR-PARTNER)",
+                in_modal: false,
+            },
+            {
+                content: "Select the # Performance Obligation",
+                trigger: ".o_field_many2one[name='performance_obligation_id'] input",
+                run: "text PB-TOUR-RR-1",
+            },
+            {
+                content: "Pick the PoB from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(PB-TOUR-RR-1)",
+                in_modal: false,
+            },
+            {
+                content: "Fill in the Date",
+                trigger: ".o_field_widget[name='date'] input",
+                run: "text 01/31/2026",
+            },
+            {
+                content: "Fill in Date Start",
+                trigger: ".o_field_widget[name='date_start'] input",
+                run: "text 01/01/2026",
+            },
+            {
+                content: "Fill in Date End",
+                trigger: ".o_field_widget[name='date_end'] input",
+                run: "text 01/31/2026",
+            },
+
+            // Flow 5 — Click Populate.
+            {
+                content: "Click Populate",
+                trigger: "button[name='action_populate']:enabled",
+                extra_trigger: ".o_form_view.o_form_editable",
+            },
+
+            // Flow 6 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Post-Condition — A new record is created in Draft.
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/revenue_recognition/02-edit.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_edit",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            // Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(RR-TOUR-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Click the Edit button.
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 4 — Change the required fields.
+            {
+                content: "Change the Date",
+                trigger: ".o_field_widget[name='date'] input",
+                run: "text 01/30/2026",
+            },
+
+            // Flow 5 — Click Populate to refresh linked data.
+            {
+                content: "Click Populate",
+                trigger: "button[name='action_populate']:enabled",
+                extra_trigger: ".o_form_view.o_form_editable",
+            },
+
+            // Flow 6 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — The record is updated.
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/revenue_recognition/03-delete.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_delete",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(RR-TOUR-DELETE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Back to the list",
+                trigger:
+                    ".breadcrumb-item.o_back_button a:contains(Revenue Recognitions)",
+            },
+            {
+                content: "The record no longer appears in the list",
+                trigger: ".o_list_view:not(:has(.o_data_row:contains(RR-TOUR-DELETE)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/revenue_recognition/04-confirm.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_confirm",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(RR-TOUR-CONFIRM) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Confirm button",
+                trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                extra_trigger: ".o_form_view",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Status is Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/revenue_recognition/05-approve.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_approve",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(RR-TOUR-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            // The single approval level is fulfilled, so the record is
+            // auto-finished (action_done) and its accounting entry is
+            // posted.
+            {
+                content: "Status is Done",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/revenue_recognition/06-reject.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_reject",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(RR-TOUR-REJECT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Reject button",
+                trigger: ".o_statusbar_buttons button[name='action_reject_approval']",
+                extra_trigger: ".o_form_view",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Status is Rejected",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='reject'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/revenue_recognition/10-cancel.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_cancel",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(RR-TOUR-CANCEL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Cancel button",
+                trigger: ".o_statusbar_buttons button:enabled:contains('Cancel')",
+            },
+            {
+                content: "Wizard is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Select the Cancellation Reason",
+                trigger:
+                    ".o_field_widget[name='cancel_reason_id'] .o_radio_item:has(label:contains(TOUR Cancel Reason)) input.o_radio_input",
+                run: "click",
+            },
+            {
+                content: "Confirm the wizard",
+                trigger: ".modal-footer button[name='action_confirm']",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Status is Cancelled",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='cancel'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/revenue_recognition/12-restart.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_restart",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(RR-TOUR-RESTART) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Restart button",
+                trigger: ".o_statusbar_buttons button[name='action_restart']",
+                extra_trigger: ".o_form_view",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Status is Draft",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+
+    // IK: docs/revenue_recognition/14-restart-approval.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_restart_approval",
+        {test: true, url: "/web"},
+        [].concat(openMenuSteps(), [
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(RR-TOUR-RESTARTAPPROVAL) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Restart Approval Process button",
+                trigger:
+                    ".o_statusbar_buttons button[name='action_reload_approval_template']",
+                extra_trigger: ".o_form_view",
+            },
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+            {
+                content: "Status is still Waiting for Approval",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ])
+    );
+});

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
@@ -267,11 +267,8 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 trigger: ".modal-footer button.btn-primary",
                 in_modal: true,
             },
-            {
-                content: "Back to the list",
-                trigger:
-                    ".breadcrumb-item.o_back_button a:contains(Revenue Recognitions)",
-            },
+            // Odoo returns straight to the list after a successful
+            // delete (no back button to click).
             {
                 content: "The record no longer appears in the list",
                 trigger: ".o_list_view:not(:has(.o_data_row:contains(RR-TOUR-DELETE)))",

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js
@@ -92,6 +92,12 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_tour", function (requir
                 trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR-RR-TYPE)",
                 in_modal: false,
             },
+            // Unearned Income Account/Income Account live on the Accounting
+            // tab, which is not the notebook's default (first) page.
+            {
+                content: "Open the Accounting tab",
+                trigger: ".o_notebook .nav-link:contains(Accounting)",
+            },
             {
                 content:
                     "Fill in the Unearned Income Account (no account mapping is configured for the product, so it was not auto-resolved)",

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_type_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_type_tour.js
@@ -103,8 +103,19 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_type_tour", function (
             // Flow 5 — Click Generate Code to assign a document code.
             {
                 content: "Click Generate Code",
-                trigger: ".o_form_view button[name='action_generate_code']",
+                trigger: ".o_form_view button[name='action_generate_code']:enabled",
                 extra_trigger: ".o_form_view.o_form_editable",
+            },
+            // `action_generate_code` is a `type="object"` button: 14.0
+            // disables it synchronously on click and only re-enables it
+            // once its full RPC + re-render cycle is done. Waiting for it
+            // to become `:enabled` again avoids Save racing that cycle.
+            {
+                content: "Generate Code finished",
+                trigger: ".o_form_view button[name='action_generate_code']:enabled",
+                run: function () {
+                    // Assertion only.
+                },
             },
 
             // Flow 6 — Click Save.

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_type_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_type_tour.js
@@ -1,0 +1,486 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_revenue_recognition.revenue_recognition_type_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/revenue_recognition_type/01-create.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_type_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the Cost Accounting > Configuration > Revenue
+            // Recognition > Revenue Recognition Types menu. The "Revenue
+            // Recognition" level is a level-3 grouping header without its
+            // own action or data-menu-xmlid, so it has no step.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_cost_accounting.menu_cost_accounting_configuration"]',
+            },
+            {
+                content: "Open the Revenue Recognition Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.revenue_recognition_type_menu"]',
+            },
+            {
+                content: "Revenue Recognition Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Revenue Recognition Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Fill in the required fields.
+            {
+                content: "Fill in Name",
+                trigger: ".o_field_widget[name='name']",
+                extra_trigger: ".o_form_view.o_form_editable",
+                run: "text TOUR-RRT-CREATE",
+            },
+            {
+                content: "Select the Journal",
+                trigger: ".o_field_many2one[name='journal_id'] input",
+                run: "text TOUR RRT Journal",
+            },
+            {
+                content: "Pick the Journal from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(TOUR RRT Journal)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Unearned Income Usage",
+                trigger: ".o_field_many2one[name='unearned_income_usage_id'] input",
+                run: "text TOUR RRT Unearned Usage",
+            },
+            {
+                content: "Pick the Unearned Income Usage from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(TOUR RRT Unearned Usage)",
+                in_modal: false,
+            },
+            {
+                content: "Select the Income Usage",
+                trigger: ".o_field_many2one[name='income_usage_id'] input",
+                run: "text TOUR RRT Income Usage",
+            },
+            {
+                content: "Pick the Income Usage from the dropdown",
+                trigger:
+                    ".ui-autocomplete .ui-menu-item a:contains(TOUR RRT Income Usage)",
+                in_modal: false,
+            },
+
+            // Flow 5 — Click Generate Code to assign a document code.
+            {
+                content: "Click Generate Code",
+                trigger: ".o_form_view button[name='action_generate_code']",
+                extra_trigger: ".o_form_view.o_form_editable",
+            },
+
+            // Flow 6 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+            {
+                content: "Record is saved",
+                trigger: ".o_form_view.o_form_readonly",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Post-Condition — A new record is created and active.
+            {
+                content: "The type is active (no Archived ribbon)",
+                trigger: ".o_form_view:not(:has(.ribbon:visible:contains(Archived)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/revenue_recognition_type/02-edit.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_type_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_cost_accounting.menu_cost_accounting_configuration"]',
+            },
+            {
+                content: "Open the Revenue Recognition Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.revenue_recognition_type_menu"]',
+            },
+            {
+                content: "Revenue Recognition Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Revenue Recognition Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Find and open the record to edit.
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(TOUR-RRT-EDIT) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Click the Edit button",
+                trigger: ".o_form_button_edit",
+            },
+            {
+                content: "Form is now editable",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Change the required fields.
+            {
+                content: "Change the Name",
+                trigger: ".o_field_widget[name='name']",
+                run: "text TOUR-RRT-EDIT (updated)",
+            },
+
+            // Flow 6 — Click Save.
+            {
+                content: "Save the record",
+                trigger: ".o_form_button_save",
+            },
+
+            // Post-Condition — The record is updated with the new values.
+            {
+                content: "Go back to the list",
+                trigger:
+                    ".breadcrumb-item:not(.active):contains(Revenue Recognition Types)",
+            },
+            {
+                content: "The updated name is shown in the list",
+                trigger: ".o_data_row:contains(TOUR-RRT-EDIT (updated))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/revenue_recognition_type/03-delete.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_type_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_cost_accounting.menu_cost_accounting_configuration"]',
+            },
+            {
+                content: "Open the Revenue Recognition Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.revenue_recognition_type_menu"]',
+            },
+            {
+                content: "Revenue Recognition Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Revenue Recognition Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Select one or more records to delete.
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-RRT-DELETE) .o_list_record_selector input",
+                extra_trigger: ".o_list_view",
+            },
+
+            // Flow 3 — Click Action > Delete.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Delete",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Delete";
+                        }
+                    );
+                    $delete[0].click();
+                },
+            },
+
+            // Flow 4 — Click OK to confirm.
+            {
+                content: "Confirm deletion",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — The record is permanently removed.
+            {
+                content: "The record no longer appears in the list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR-RRT-DELETE)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/revenue_recognition_type/04-deactivate.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_type_deactivate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_cost_accounting.menu_cost_accounting_configuration"]',
+            },
+            {
+                content: "Open the Revenue Recognition Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.revenue_recognition_type_menu"]',
+            },
+            {
+                content: "Revenue Recognition Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Revenue Recognition Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Select one or more records to deactivate.
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-RRT-DEACTIVATE) .o_list_record_selector input",
+                extra_trigger: ".o_list_view",
+            },
+
+            // Flow 3 — Click Action > Archive.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Archive",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $archive = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Archive";
+                        }
+                    );
+                    $archive[0].click();
+                },
+            },
+
+            // Flow 4 — Click OK to confirm.
+            {
+                content: "Confirm archiving",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Post-Condition — The record is archived and no longer listed.
+            {
+                content: "The record no longer appears in the default list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR-RRT-DEACTIVATE)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+
+    // IK: docs/revenue_recognition_type/05-activate.md
+    tour.register(
+        "ssi_revenue_recognition_revenue_recognition_type_activate",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            // Flow 1 — Open the menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Configuration menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_cost_accounting.menu_cost_accounting_configuration"]',
+            },
+            {
+                content: "Open the Revenue Recognition Types menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.revenue_recognition_type_menu"]',
+            },
+            {
+                content: "Revenue Recognition Types list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Revenue Recognition Types)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 2 — Enable the Archived filter.
+            {
+                content: "Open the Filters menu",
+                trigger: ".o_search_options .o_filter_menu button",
+            },
+            {
+                content: "Enable the Archived filter",
+                trigger: ".o_filter_menu .dropdown-item:contains(Archived)",
+                run: function () {
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "Archived filter is active",
+                trigger:
+                    ".o_filter_menu .dropdown-item:contains(Archived)[aria-checked='true']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Flow 3 — Select one or more records to reactivate.
+            {
+                content: "Select the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-RRT-ACTIVATE) .o_list_record_selector input",
+                extra_trigger: ".o_list_view",
+            },
+
+            // Flow 4 — Click Action > Unarchive. No confirmation dialog.
+            {
+                content: "Open the Action menu",
+                trigger: ".o_cp_action_menus button:contains(Action)",
+            },
+            {
+                content: "Click Unarchive",
+                trigger: ".o_cp_action_menus .o_menu_item a",
+                run: function () {
+                    var $unarchive = $(".o_cp_action_menus .o_menu_item a").filter(
+                        function () {
+                            return $(this).text().trim() === "Unarchive";
+                        }
+                    );
+                    $unarchive[0].click();
+                },
+            },
+
+            // Post-Condition — The record is restored, appears in the
+            // default list again.
+            {
+                content: "Disable the Archived filter to see the default list",
+                trigger: ".o_search_options .o_filter_menu button",
+            },
+            {
+                content: "Open the Archived filter toggle again",
+                trigger: ".o_filter_menu .dropdown-item:contains(Archived)",
+                run: function () {
+                    this.$anchor[0].click();
+                },
+            },
+            {
+                content: "The record appears again in the default list",
+                trigger: ".o_data_row:contains(TOUR-RRT-ACTIVATE)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_type_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_type_tour.js
@@ -194,7 +194,7 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_type_tour", function (
             {
                 content: "Change the Name",
                 trigger: ".o_field_widget[name='name']",
-                run: "text TOUR-RRT-EDIT (updated)",
+                run: "text TOUR-RRT-EDIT-UPDATED",
             },
 
             // Flow 6 — Click Save.
@@ -211,7 +211,7 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_type_tour", function (
             },
             {
                 content: "The updated name is shown in the list",
-                trigger: ".o_data_row:contains(TOUR-RRT-EDIT (updated))",
+                trigger: ".o_data_row:contains(TOUR-RRT-EDIT-UPDATED)",
                 run: function () {
                     // Assertion only.
                 },

--- a/ssi_revenue_recognition/tests/__init__.py
+++ b/ssi_revenue_recognition/tests/__init__.py
@@ -6,3 +6,7 @@ from . import test_account_analytic_account
 from . import test_performance_obligation
 from . import test_revenue_recognition
 from . import test_revenue_recognition_type
+from . import test_ui_revenue_recognition_type
+from . import test_ui_performance_obligation
+from . import test_ui_performance_obligation_acceptance
+from . import test_ui_revenue_recognition

--- a/ssi_revenue_recognition/tests/test_ui_performance_obligation.py
+++ b/ssi_revenue_recognition/tests/test_ui_performance_obligation.py
@@ -1,0 +1,187 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPerformanceObligation(HttpSavepointCase):
+    """Tour tests for the ``performance_obligation`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the analytic accounts and PoB fixtures the tours need."""
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: Confirm/Cancel need `*_user_group`, Approve/Reject/
+        # Restart need `*_validator_group` (the approval template's approver
+        # group). Both are granted to admin so every tour's button renders.
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_user_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_validator_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+        # Pre-Condition of the cancel tour: a cancel reason must exist.
+        # `global_use=True` makes it selectable for every model, including
+        # `performance_obligation`.
+        cls.env["base.cancel_reason"].create(
+            {"name": "TOUR Cancel Reason", "code": "TOURCR", "global_use": True}
+        )
+
+        AA = cls.env["account.analytic.account"]
+        cls.source_aa = AA.create({"name": "TOUR-POB-SOURCE-AA"})
+
+        Pob = cls.env["performance_obligation"]
+        cls.pob_create = Pob.create(
+            {
+                "title": "TOUR-POB-CREATE",
+                "source_analytic_account_id": cls.source_aa.id,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.pob_edit = Pob.create(
+            {
+                "title": "TOUR-POB-EDIT",
+                "source_analytic_account_id": cls.source_aa.id,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.pob_delete = Pob.create(
+            {
+                "title": "TOUR-POB-DELETE",
+                "source_analytic_account_id": cls.source_aa.id,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.pob_confirm = Pob.create(
+            {
+                "title": "TOUR-POB-CONFIRM",
+                "source_analytic_account_id": cls.source_aa.id,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.pob_approve = Pob.create(
+            {
+                "title": "TOUR-POB-APPROVE",
+                "source_analytic_account_id": cls.source_aa.id,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.pob_approve.action_confirm()
+        cls.pob_approve.invalidate_cache()
+        cls.pob_reject = Pob.create(
+            {
+                "title": "TOUR-POB-REJECT",
+                "source_analytic_account_id": cls.source_aa.id,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.pob_reject.action_confirm()
+        cls.pob_reject.invalidate_cache()
+        cls.pob_cancel = Pob.create(
+            {
+                "title": "TOUR-POB-CANCEL",
+                "source_analytic_account_id": cls.source_aa.id,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.pob_restart = Pob.create(
+            {
+                "title": "TOUR-POB-RESTART",
+                "source_analytic_account_id": cls.source_aa.id,
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.pob_restart.action_cancel()
+
+    def test_create(self):
+        """Run the create tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_delete",
+            login="admin",
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/04-confirm.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_confirm",
+            login="admin",
+        )
+
+    def test_approve(self):
+        """Run the approve tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_approve",
+            login="admin",
+        )
+
+    def test_reject(self):
+        """Run the reject tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/06-reject.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_reject",
+            login="admin",
+        )
+
+    def test_cancel(self):
+        """Run the cancel tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/10-cancel.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_cancel",
+            login="admin",
+        )
+
+    def test_restart(self):
+        """Run the restart tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/12-restart.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_restart",
+            login="admin",
+        )

--- a/ssi_revenue_recognition/tests/test_ui_performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition/tests/test_ui_performance_obligation_acceptance.py
@@ -1,0 +1,188 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPerformanceObligationAcceptance(HttpSavepointCase):
+    """Tour tests for the ``performance_obligation_acceptance`` work
+    instructions.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the partner, an Open PoB, and the acceptance fixtures."""
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: Confirm needs `*_user_group`; Approve/Reject/
+        # Cancel/Restart/Restart Approval need `*_validator_group`.
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_acceptance_user_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_acceptance_validator_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+        # Pre-Condition of the cancel tour: a cancel reason must exist.
+        # `global_use=True` makes it selectable for every model.
+        cls.env["base.cancel_reason"].create(
+            {"name": "TOUR Cancel Reason", "code": "TOURCR", "global_use": True}
+        )
+
+        cls.partner = cls.env["res.partner"].create({"name": "TOUR-POBA-PARTNER"})
+        source_aa = cls.env["account.analytic.account"].create(
+            {"name": "TOUR-POBA-SOURCE-AA", "partner_id": cls.partner.id}
+        )
+        # Background data: an already-Open PoB the acceptance tours pick
+        # from the `# Performance Obligation` dropdown. Its own workflow is
+        # not under test here, so the state is set directly instead of
+        # running the full approval chain.
+        cls.pob = cls.env["performance_obligation"].create(
+            {
+                "title": "TOUR-POBA-POB",
+                "source_analytic_account_id": source_aa.id,
+                "user_id": cls.admin.id,
+                "name": "PB-TOUR-POBA-1",
+            }
+        )
+        cls.pob.write({"state": "open"})
+
+        Poa = cls.env["performance_obligation_acceptance"]
+
+        def _create(name):
+            """Create a draft acceptance fixture with the given ``name``.
+
+            :param name: value assigned to the document number field,
+                so the tour can select the record via its display name.
+            :return: the created ``performance_obligation_acceptance``
+                record.
+            """
+            return Poa.create(
+                {
+                    "name": name,
+                    "partner_id": cls.partner.id,
+                    "performance_obligation_id": cls.pob.id,
+                    "date": "2026-01-15",
+                    "date_start": "2026-01-01",
+                    "date_end": "2026-01-31",
+                    "user_id": cls.admin.id,
+                }
+            )
+
+        cls.poa_edit = _create("POA-TOUR-EDIT")
+        cls.poa_delete = _create("POA-TOUR-DELETE")
+        cls.poa_confirm = _create("POA-TOUR-CONFIRM")
+        cls.poa_approve = _create("POA-TOUR-APPROVE")
+        cls.poa_approve.action_confirm()
+        cls.poa_approve.invalidate_cache()
+        cls.poa_reject = _create("POA-TOUR-REJECT")
+        cls.poa_reject.action_confirm()
+        cls.poa_reject.invalidate_cache()
+        cls.poa_cancel = _create("POA-TOUR-CANCEL")
+        cls.poa_restart = _create("POA-TOUR-RESTART")
+        cls.poa_restart.action_cancel()
+        cls.poa_restart_approval = _create("POA-TOUR-RESTARTAPPROVAL")
+        cls.poa_restart_approval.action_confirm()
+        cls.poa_restart_approval.invalidate_cache()
+
+    def test_create(self):
+        """Run the create tour for ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_acceptance_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_acceptance_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_acceptance_delete",
+            login="admin",
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/04-confirm.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_acceptance_confirm",
+            login="admin",
+        )
+
+    def test_approve(self):
+        """Run the approve tour for ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_acceptance_approve",
+            login="admin",
+        )
+
+    def test_reject(self):
+        """Run the reject tour for ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/06-reject.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_acceptance_reject",
+            login="admin",
+        )
+
+    def test_cancel(self):
+        """Run the cancel tour for ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/10-cancel.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_acceptance_cancel",
+            login="admin",
+        )
+
+    def test_restart(self):
+        """Run the restart tour for ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/12-restart.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_acceptance_restart",
+            login="admin",
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval tour for ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_performance_obligation_acceptance_restart_approval",
+            login="admin",
+        )

--- a/ssi_revenue_recognition/tests/test_ui_performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition/tests/test_ui_performance_obligation_acceptance.py
@@ -33,6 +33,14 @@ class TestUiPerformanceObligationAcceptance(HttpSavepointCase):
         )
 
         cls.partner = cls.env["res.partner"].create({"name": "TOUR-POBA-PARTNER"})
+        # Dedicated partner for the delete fixture (see `_create` below):
+        # its document number must stay "/" for `unlink()` to succeed
+        # (`_check_document_number_unlink`), so it cannot be identified
+        # in the list by its "# Document" text like the other fixtures.
+        # This partner is the row's identifying text instead.
+        cls.partner_delete = cls.env["res.partner"].create(
+            {"name": "TOUR-POBA-DELETE-PARTNER"}
+        )
         source_aa = cls.env["account.analytic.account"].create(
             {"name": "TOUR-POBA-SOURCE-AA", "partner_id": cls.partner.id}
         )
@@ -52,28 +60,36 @@ class TestUiPerformanceObligationAcceptance(HttpSavepointCase):
 
         Poa = cls.env["performance_obligation_acceptance"]
 
-        def _create(name):
+        def _create(name, partner=None):
             """Create a draft acceptance fixture with the given ``name``.
 
             :param name: value assigned to the document number field,
                 so the tour can select the record via its display name.
+                Pass ``None`` to leave it at its "/" default (required
+                for a fixture that the tour will delete, since
+                `unlink()` refuses any document number other than "/").
+            :param partner: partner to link; defaults to
+                ``cls.partner``.
             :return: the created ``performance_obligation_acceptance``
                 record.
             """
-            return Poa.create(
-                {
-                    "name": name,
-                    "partner_id": cls.partner.id,
-                    "performance_obligation_id": cls.pob.id,
-                    "date": "2026-01-15",
-                    "date_start": "2026-01-01",
-                    "date_end": "2026-01-31",
-                    "user_id": cls.admin.id,
-                }
-            )
+            values = {
+                "partner_id": (partner or cls.partner).id,
+                "performance_obligation_id": cls.pob.id,
+                "date": "2026-01-15",
+                "date_start": "2026-01-01",
+                "date_end": "2026-01-31",
+                "user_id": cls.admin.id,
+            }
+            if name is not None:
+                values["name"] = name
+            return Poa.create(values)
 
         cls.poa_edit = _create("POA-TOUR-EDIT")
-        cls.poa_delete = _create("POA-TOUR-DELETE")
+        # Document number stays "/" (see `_create` docstring): the delete
+        # tour identifies this row by its dedicated partner instead of by
+        # "# Document" text.
+        cls.poa_delete = _create(None, partner=cls.partner_delete)
         cls.poa_confirm = _create("POA-TOUR-CONFIRM")
         cls.poa_approve = _create("POA-TOUR-APPROVE")
         cls.poa_approve.action_confirm()

--- a/ssi_revenue_recognition/tests/test_ui_revenue_recognition.py
+++ b/ssi_revenue_recognition/tests/test_ui_revenue_recognition.py
@@ -71,6 +71,7 @@ class TestUiRevenueRecognition(HttpSavepointCase):
         cls.rr_type = cls.env["revenue_recognition_type"].create(
             {
                 "name": "TOUR-RR-TYPE",
+                "code": "TOURRRTYPE",
                 "journal_id": journal.id,
                 "unearned_income_usage_id": usage.id,
                 "income_usage_id": usage.id,

--- a/ssi_revenue_recognition/tests/test_ui_revenue_recognition.py
+++ b/ssi_revenue_recognition/tests/test_ui_revenue_recognition.py
@@ -1,0 +1,239 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiRevenueRecognition(HttpSavepointCase):
+    """Tour tests for the ``revenue_recognition`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the type, an Open PoB with a Done acceptance, and RR
+        fixtures.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: Confirm needs `*_user_group`; Approve/Reject/
+        # Cancel/Restart/Restart Approval need `*_validator_group`.
+        cls.env.ref(
+            "ssi_revenue_recognition.revenue_recognition_user_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+        cls.env.ref(
+            "ssi_revenue_recognition.revenue_recognition_validator_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+        # Pre-Condition of the cancel tour: a cancel reason must exist.
+        # `global_use=True` makes it selectable for every model.
+        cls.env["base.cancel_reason"].create(
+            {"name": "TOUR Cancel Reason", "code": "TOURCR", "global_use": True}
+        )
+
+        cls.partner = cls.env["res.partner"].create({"name": "TOUR-RR-PARTNER"})
+        source_aa = cls.env["account.analytic.account"].create(
+            {"name": "TOUR-RR-SOURCE-AA", "partner_id": cls.partner.id}
+        )
+        # Background data: an Open PoB with a Done acceptance, so the
+        # `# Performance Obligation` dropdown and the `Populate` action have
+        # something to work with. Neither model's own workflow is under
+        # test here, so their state is set directly.
+        cls.pob = cls.env["performance_obligation"].create(
+            {
+                "title": "TOUR-RR-POB",
+                "source_analytic_account_id": source_aa.id,
+                "user_id": cls.admin.id,
+                "name": "PB-TOUR-RR-1",
+            }
+        )
+        cls.pob.write({"state": "open"})
+        cls.poa = cls.env["performance_obligation_acceptance"].create(
+            {
+                "name": "POA-TOUR-RR-1",
+                "partner_id": cls.partner.id,
+                "performance_obligation_id": cls.pob.id,
+                "date": "2026-01-15",
+                "date_start": "2026-01-01",
+                "date_end": "2026-01-31",
+                "user_id": cls.admin.id,
+            }
+        )
+        cls.poa.write({"state": "done"})
+
+        journal = cls.env["account.journal"].create(
+            {"name": "TOUR RR Journal", "code": "TOURRRJ", "type": "general"}
+        )
+        usage = cls.env["product.usage_type"].create(
+            {"name": "TOUR RR Usage", "code": "TOURRRUS"}
+        )
+        cls.rr_type = cls.env["revenue_recognition_type"].create(
+            {
+                "name": "TOUR-RR-TYPE",
+                "journal_id": journal.id,
+                "unearned_income_usage_id": usage.id,
+                "income_usage_id": usage.id,
+            }
+        )
+        unearned_account = cls.env["account.account"].create(
+            {
+                "name": "TOUR RR Unearned Income Account",
+                "code": "TOURRRUA",
+                "user_type_id": cls.env.ref(
+                    "account.data_account_type_current_liabilities"
+                ).id,
+            }
+        )
+        income_account = cls.env["account.account"].create(
+            {
+                "name": "TOUR RR Income Account",
+                "code": "TOURRRIA",
+                "user_type_id": cls.env.ref("account.data_account_type_revenue").id,
+            }
+        )
+
+        Rr = cls.env["revenue_recognition"]
+
+        def _create(name):
+            """Create a draft RR fixture with the given ``name``, populated.
+
+            :param name: value assigned to the document number field,
+                so the tour can select the record via its display name.
+            :return: the created ``revenue_recognition`` record, after
+                running the same population steps as the ``Populate``
+                button.
+            """
+            record = Rr.create(
+                {
+                    "name": name,
+                    "type_id": cls.rr_type.id,
+                    "journal_id": journal.id,
+                    "partner_id": cls.partner.id,
+                    "performance_obligation_id": cls.pob.id,
+                    "unearned_income_account_id": unearned_account.id,
+                    "income_account_id": income_account.id,
+                    "date": "2026-01-31",
+                    "date_start": "2026-01-01",
+                    "date_end": "2026-01-31",
+                    "user_id": cls.admin.id,
+                }
+            )
+            record._populate_pob_acceptances()
+            record._populate_wip_move_line()
+            return record
+
+        cls.rr_edit = _create("RR-TOUR-EDIT")
+        cls.rr_delete = _create("RR-TOUR-DELETE")
+        cls.rr_confirm = _create("RR-TOUR-CONFIRM")
+        cls.rr_approve = _create("RR-TOUR-APPROVE")
+        cls.rr_approve.action_confirm()
+        cls.rr_approve.invalidate_cache()
+        cls.rr_reject = _create("RR-TOUR-REJECT")
+        cls.rr_reject.action_confirm()
+        cls.rr_reject.invalidate_cache()
+        cls.rr_cancel = _create("RR-TOUR-CANCEL")
+        cls.rr_restart = _create("RR-TOUR-RESTART")
+        cls.rr_restart.action_cancel()
+        cls.rr_restart_approval = _create("RR-TOUR-RESTARTAPPROVAL")
+        cls.rr_restart_approval.action_confirm()
+        cls.rr_restart_approval.invalidate_cache()
+
+    def test_create(self):
+        """Run the create tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_delete",
+            login="admin",
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/04-confirm.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_confirm",
+            login="admin",
+        )
+
+    def test_approve(self):
+        """Run the approve tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_approve",
+            login="admin",
+        )
+
+    def test_reject(self):
+        """Run the reject tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/06-reject.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_reject",
+            login="admin",
+        )
+
+    def test_cancel(self):
+        """Run the cancel tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/10-cancel.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_cancel",
+            login="admin",
+        )
+
+    def test_restart(self):
+        """Run the restart tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/12-restart.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_restart",
+            login="admin",
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/14-restart-approval.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_restart_approval",
+            login="admin",
+        )

--- a/ssi_revenue_recognition/tests/test_ui_revenue_recognition.py
+++ b/ssi_revenue_recognition/tests/test_ui_revenue_recognition.py
@@ -33,6 +33,14 @@ class TestUiRevenueRecognition(HttpSavepointCase):
         )
 
         cls.partner = cls.env["res.partner"].create({"name": "TOUR-RR-PARTNER"})
+        # Dedicated partner for the delete fixture (see `_create` below):
+        # its document number must stay "/" for `unlink()` to succeed
+        # (`_check_document_number_unlink`), so it cannot be identified
+        # in the list by its "# Document" text like the other fixtures.
+        # This partner is the row's identifying text instead.
+        cls.partner_delete = cls.env["res.partner"].create(
+            {"name": "TOUR-RR-DELETE-PARTNER"}
+        )
         source_aa = cls.env["account.analytic.account"].create(
             {"name": "TOUR-RR-SOURCE-AA", "partner_id": cls.partner.id}
         )
@@ -105,36 +113,44 @@ class TestUiRevenueRecognition(HttpSavepointCase):
 
         Rr = cls.env["revenue_recognition"]
 
-        def _create(name):
+        def _create(name, partner=None):
             """Create a draft RR fixture with the given ``name``, populated.
 
             :param name: value assigned to the document number field,
                 so the tour can select the record via its display name.
+                Pass ``None`` to leave it at its "/" default (required
+                for a fixture that the tour will delete, since
+                `unlink()` refuses any document number other than "/").
+            :param partner: partner to link; defaults to
+                ``cls.partner``.
             :return: the created ``revenue_recognition`` record, after
                 running the same population steps as the ``Populate``
                 button.
             """
-            record = Rr.create(
-                {
-                    "name": name,
-                    "type_id": cls.rr_type.id,
-                    "journal_id": journal.id,
-                    "partner_id": cls.partner.id,
-                    "performance_obligation_id": cls.pob.id,
-                    "unearned_income_account_id": unearned_account.id,
-                    "income_account_id": income_account.id,
-                    "date": "2026-01-31",
-                    "date_start": "2026-01-01",
-                    "date_end": "2026-01-31",
-                    "user_id": cls.admin.id,
-                }
-            )
+            values = {
+                "type_id": cls.rr_type.id,
+                "journal_id": journal.id,
+                "partner_id": (partner or cls.partner).id,
+                "performance_obligation_id": cls.pob.id,
+                "unearned_income_account_id": unearned_account.id,
+                "income_account_id": income_account.id,
+                "date": "2026-01-31",
+                "date_start": "2026-01-01",
+                "date_end": "2026-01-31",
+                "user_id": cls.admin.id,
+            }
+            if name is not None:
+                values["name"] = name
+            record = Rr.create(values)
             record._populate_pob_acceptances()
             record._populate_wip_move_line()
             return record
 
         cls.rr_edit = _create("RR-TOUR-EDIT")
-        cls.rr_delete = _create("RR-TOUR-DELETE")
+        # Document number stays "/" (see `_create` docstring): the delete
+        # tour identifies this row by its dedicated partner instead of by
+        # "# Document" text.
+        cls.rr_delete = _create(None, partner=cls.partner_delete)
         cls.rr_confirm = _create("RR-TOUR-CONFIRM")
         cls.rr_approve = _create("RR-TOUR-APPROVE")
         cls.rr_approve.action_confirm()

--- a/ssi_revenue_recognition/tests/test_ui_revenue_recognition.py
+++ b/ssi_revenue_recognition/tests/test_ui_revenue_recognition.py
@@ -36,6 +36,14 @@ class TestUiRevenueRecognition(HttpSavepointCase):
         source_aa = cls.env["account.analytic.account"].create(
             {"name": "TOUR-RR-SOURCE-AA", "partner_id": cls.partner.id}
         )
+        # `product_id` on the PoB must be set: `revenue_recognition.product_id`
+        # is a related field through `performance_obligation_id`, and the
+        # `type_id`-triggered onchanges resolving the Unearned Income/Income
+        # Account call `self.product_id._get_product_account(...)`, which
+        # requires a singleton. The create tour selects `# Performance
+        # Obligation` before `Type` precisely so this related `product_id`
+        # is already populated by the time those onchanges run.
+        product = cls.env["product.product"].create({"name": "TOUR RR Product"})
         # Background data: an Open PoB with a Done acceptance, so the
         # `# Performance Obligation` dropdown and the `Populate` action have
         # something to work with. Neither model's own workflow is under
@@ -46,6 +54,7 @@ class TestUiRevenueRecognition(HttpSavepointCase):
                 "source_analytic_account_id": source_aa.id,
                 "user_id": cls.admin.id,
                 "name": "PB-TOUR-RR-1",
+                "product_id": product.id,
             }
         )
         cls.pob.write({"state": "open"})

--- a/ssi_revenue_recognition/tests/test_ui_revenue_recognition_type.py
+++ b/ssi_revenue_recognition/tests/test_ui_revenue_recognition_type.py
@@ -50,6 +50,7 @@ class TestUiRevenueRecognitionType(HttpSavepointCase):
         cls.rrt_edit = Type.create(
             {
                 "name": "TOUR-RRT-EDIT",
+                "code": "TOURRRTEDIT",
                 "journal_id": journal.id,
                 "unearned_income_usage_id": usage.id,
                 "income_usage_id": usage.id,
@@ -58,6 +59,7 @@ class TestUiRevenueRecognitionType(HttpSavepointCase):
         cls.rrt_delete = Type.create(
             {
                 "name": "TOUR-RRT-DELETE",
+                "code": "TOURRRTDEL",
                 "journal_id": journal.id,
                 "unearned_income_usage_id": usage.id,
                 "income_usage_id": usage.id,
@@ -66,6 +68,7 @@ class TestUiRevenueRecognitionType(HttpSavepointCase):
         cls.rrt_deactivate = Type.create(
             {
                 "name": "TOUR-RRT-DEACTIVATE",
+                "code": "TOURRRTDEACT",
                 "journal_id": journal.id,
                 "unearned_income_usage_id": usage.id,
                 "income_usage_id": usage.id,
@@ -74,6 +77,7 @@ class TestUiRevenueRecognitionType(HttpSavepointCase):
         cls.rrt_activate = Type.create(
             {
                 "name": "TOUR-RRT-ACTIVATE",
+                "code": "TOURRRTACT",
                 "journal_id": journal.id,
                 "unearned_income_usage_id": usage.id,
                 "income_usage_id": usage.id,

--- a/ssi_revenue_recognition/tests/test_ui_revenue_recognition_type.py
+++ b/ssi_revenue_recognition/tests/test_ui_revenue_recognition_type.py
@@ -1,0 +1,138 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiRevenueRecognitionType(HttpSavepointCase):
+    """Tour tests for the ``revenue_recognition_type`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant the configurator group and create the type fixtures."""
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: this master data menu is gated by the configurator
+        # group. Without it the tour dies on its FIRST step — the menu is
+        # never rendered.
+        cls.env.ref(
+            "ssi_revenue_recognition.revenue_recognition_type_configuration_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+        # m2o dropdown data picked by the create tour, per the identifier
+        # in each step's `run: "text ..."` / `:contains(...)`.
+        cls.env["account.journal"].create(
+            {
+                "name": "TOUR RRT Journal",
+                "code": "TOURRRTJ",
+                "type": "general",
+            }
+        )
+        cls.env["product.usage_type"].create(
+            {
+                "name": "TOUR RRT Unearned Usage",
+                "code": "TOURRRTU",
+            }
+        )
+        cls.env["product.usage_type"].create(
+            {
+                "name": "TOUR RRT Income Usage",
+                "code": "TOURRRTI",
+            }
+        )
+
+        Type = cls.env["revenue_recognition_type"]
+        journal = cls.env["account.journal"].search([("type", "=", "general")], limit=1)
+        usage = cls.env["product.usage_type"].search([], limit=1)
+        cls.rrt_edit = Type.create(
+            {
+                "name": "TOUR-RRT-EDIT",
+                "journal_id": journal.id,
+                "unearned_income_usage_id": usage.id,
+                "income_usage_id": usage.id,
+            }
+        )
+        cls.rrt_delete = Type.create(
+            {
+                "name": "TOUR-RRT-DELETE",
+                "journal_id": journal.id,
+                "unearned_income_usage_id": usage.id,
+                "income_usage_id": usage.id,
+            }
+        )
+        cls.rrt_deactivate = Type.create(
+            {
+                "name": "TOUR-RRT-DEACTIVATE",
+                "journal_id": journal.id,
+                "unearned_income_usage_id": usage.id,
+                "income_usage_id": usage.id,
+            }
+        )
+        cls.rrt_activate = Type.create(
+            {
+                "name": "TOUR-RRT-ACTIVATE",
+                "journal_id": journal.id,
+                "unearned_income_usage_id": usage.id,
+                "income_usage_id": usage.id,
+            }
+        )
+        # Pre-Condition of the activate tour: the record starts archived.
+        cls.rrt_activate.write({"active": False})
+
+    def test_create(self):
+        """Run the create tour for ``revenue_recognition_type``.
+
+        IK: docs/revenue_recognition_type/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_type_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``revenue_recognition_type``.
+
+        IK: docs/revenue_recognition_type/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_type_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``revenue_recognition_type``.
+
+        IK: docs/revenue_recognition_type/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_type_delete",
+            login="admin",
+        )
+
+    def test_deactivate(self):
+        """Run the deactivate tour for ``revenue_recognition_type``.
+
+        IK: docs/revenue_recognition_type/04-deactivate.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_type_deactivate",
+            login="admin",
+        )
+
+    def test_activate(self):
+        """Run the activate tour for ``revenue_recognition_type``.
+
+        IK: docs/revenue_recognition_type/05-activate.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_revenue_recognition_type_activate",
+            login="admin",
+        )

--- a/ssi_revenue_recognition/views/assets.xml
+++ b/ssi_revenue_recognition/views/assets.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_revenue_recognition assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition/static/tests/tours/revenue_recognition_type_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition/static/tests/tours/performance_obligation_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition/static/tests/tours/performance_obligation_acceptance_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition/static/tests/tours/revenue_recognition_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan direktori `docs/` (Instruksi Kerja) untuk keempat model
berpermukaan pengguna di modul `ssi_revenue_recognition`, beserta satu tour
Odoo per berkas IK:

- `revenue_recognition_type` (master data): create, edit, delete, deactivate,
  activate.
- `performance_obligation` (transaksional): create, edit, delete, confirm,
  approve, reject, auto-done (base.automation, tanpa tour), cancel, restart.
- `performance_obligation_acceptance` (transaksional): create, edit, delete,
  confirm, approve, reject, cancel, restart, restart approval.
- `revenue_recognition` (transaksional): create, edit, delete, confirm,
  approve, reject, cancel, restart, restart approval. `action_populate`
  didokumentasikan sebagai langkah inline di IK create & edit (metadata
  `Inline Actions:`), tanpa berkas IK tersendiri.

Tidak ada perubahan model, view, atau security. Item ini menutup temuan
sapuan audit `ik` (`modul belum punya direktori docs/`).

Closes open-synergy/ssi-revenue-recognition#51

## Test plan

- [x] `validate-ik.sh` — 0 ERROR
- [x] `validate-tour.sh` — 0 ERROR
- [x] `verify-module.sh` — 0 ERROR
- [x] `pre-commit-gate.sh` — GATE OK (6 validator, 0 pelanggaran baru)
- [ ] CI hijau (unit test YAML tak berubah; tour dijalankan CI)