### PR TITLE
[UPD] ssi_revenue_recognition - Guard action_open() dari state tak sah

### DIFF
--- a/ssi_revenue_recognition/models/performance_obligation.py
+++ b/ssi_revenue_recognition/models/performance_obligation.py
@@ -2,7 +2,8 @@
 # Copyright 2022 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 from odoo.addons.ssi_decorator import ssi_decorator
 
@@ -431,6 +432,50 @@ class PerformanceObligation(models.Model):
         if not source or source == self.analytic_account_id:
             return False
         return source.id
+
+    @ssi_decorator.pre_open_check()
+    def _10_check_open_source_state(self):
+        """Block ``action_open`` when called from a state that is not
+        allowed to open.
+
+        ``_automatically_insert_open_button`` is ``False`` on this
+        model, so ``_check_open_policy()`` returns early and never
+        evaluates ``open_ok`` -- the ``draft -> open`` transition is
+        gated by ``approval.template`` instead
+        (``_after_approved_method = "action_open"``). Without this
+        hook ``action_open()`` can be called from any state, writing
+        ``open`` and running every ``post_open_action`` side effect
+        (analytic account creation, project creation) unconditionally.
+
+        Runs in the ``pre_open_check`` slot, before
+        ``record.write(record._prepare_open_data())``, so raising here
+        leaves ``state`` and every derived record untouched.
+
+        Allowed source states:
+
+        * ``confirm`` -- the approval flow: ``_action_approval``
+          does not write the state itself; ``action_open`` is called
+          by ``mixin_multiple_approval`` while the record is still
+          ``confirm``.
+        * ``done`` -- the ``pob_done_2_open`` automation
+          (``data/base_automation_data.xml``) reopens a ``done`` PoB
+          when ``quantity_diff`` changes back to non-zero.
+
+        :raises UserError: when ``state`` is neither ``confirm`` nor
+            ``done``.
+        """
+        self.ensure_one()
+        if self.state not in ("confirm", "done"):
+            error_message = _(
+                """
+Context: Open document
+Database ID: %s
+Problem: Document cannot be opened from its current state
+Solution: Open the document only from the Confirm or Done state
+"""
+                % (self.id,)
+            )
+            raise UserError(error_message)
 
     @ssi_decorator.post_open_action()
     def _10_create_analytic_account(self):

--- a/ssi_revenue_recognition/static/tests/tours/revenue_recognition_type_tour.js
+++ b/ssi_revenue_recognition/static/tests/tours/revenue_recognition_type_tour.js
@@ -471,6 +471,20 @@ odoo.define("ssi_revenue_recognition.revenue_recognition_type_tour", function (
                     $unarchive[0].click();
                 },
             },
+            // Unarchiving is an async write + list refresh. The list is
+            // still Archived-filtered at this point, so the record
+            // disappearing from it is the signal that the write landed —
+            // wait for that before touching the filter, otherwise removing
+            // the Archived filter can race the still-in-flight refresh and
+            // read a stale (still-archived) record.
+            {
+                content: "The record no longer appears in the Archived list",
+                trigger:
+                    ".o_list_view:not(:has(.o_data_row:contains(TOUR-RRT-ACTIVATE)))",
+                run: function () {
+                    // Assertion only.
+                },
+            },
 
             // Post-Condition — The record is restored, appears in the
             // default list again.

--- a/ssi_revenue_recognition/tests/__init__.py
+++ b/ssi_revenue_recognition/tests/__init__.py
@@ -4,6 +4,7 @@
 
 from . import test_account_analytic_account
 from . import test_performance_obligation
+from . import test_performance_obligation_open_guard
 from . import test_revenue_recognition
 from . import test_revenue_recognition_type
 from . import test_ui_revenue_recognition_type

--- a/ssi_revenue_recognition/tests/test_data_performance_obligation_open_guard.yaml
+++ b/ssi_revenue_recognition/tests/test_data_performance_obligation_open_guard.yaml
@@ -1,0 +1,238 @@
+scenarios:
+  - name: "action_open is rejected on a draft PoB"
+    steps:
+      - step: "Create source analytic account of the contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_1"
+        values:
+          name: "Test Source AA - Open Guard Draft 1"
+
+      - step: "Create draft PoB pointing at the source analytic account"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_1"
+        values:
+          title: "Test PoB - Open Guard Draft 1"
+          source_analytic_account_id: "REC: source_aa_1.id"
+
+      - step: "action_open on a draft PoB is rejected"
+        action: "call"
+        target: "pob_1"
+        method: "action_open"
+        expect_error:
+          type: "UserError"
+          message_contains: "Document cannot be opened from its current state"
+
+      - step: "State stays draft and no analytic account was created"
+        action: "assert"
+        target: "pob_1"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+          analytic_account_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "action_open is rejected on a PoB already open"
+    steps:
+      - step: "Create source analytic account of the contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_2"
+        values:
+          name: "Test Source AA - Open Guard Already Open 2"
+
+      - step: "Create draft PoB as admin (owns the record for as_user steps)"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_2"
+        as_user: "base.user_admin"
+        values:
+          title: "Test PoB - Open Guard Already Open 2"
+          source_analytic_account_id: "REC: source_aa_2.id"
+
+      - step: "Confirm the PoB"
+        action: "call"
+        target: "pob_2"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04) -- tanpa
+      # step ini approve_ok bisa terbaca dari cache yang diisi
+      # action_confirm, saat approval.approval belum ada.
+      - step: "PoB is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "pob_2"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the PoB (auto-runs action_open via _after_approved_method)"
+        action: "call"
+        target: "pob_2"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "action_open on an already-open PoB is rejected"
+        action: "call"
+        target: "pob_2"
+        method: "action_open"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "UserError"
+          message_contains: "Document cannot be opened from its current state"
+
+      - step: "State stays open, the rejected call did not disturb it"
+        action: "assert"
+        target: "pob_2"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+  - name: "Approval flow reaches open (regression guard)"
+    steps:
+      - step: "Create source analytic account of the contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_3"
+        values:
+          name: "Test Source AA - Open Guard Approval Flow 3"
+
+      - step: "Create draft PoB as admin"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_3"
+        as_user: "base.user_admin"
+        values:
+          title: "Test PoB - Open Guard Approval Flow 3"
+          source_analytic_account_id: "REC: source_aa_3.id"
+
+      - step: "PoB starts draft with no analytic account yet"
+        action: "assert"
+        target: "pob_3"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+          analytic_account_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Confirm the PoB"
+        action: "call"
+        target: "pob_3"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04).
+      - step: "PoB is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "pob_3"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the PoB reaches open through the guarded hook"
+        action: "call"
+        target: "pob_3"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "post_open_action ran: the PoB owns an analytic account"
+        action: "assert"
+        target: "pob_3"
+        asserts:
+          analytic_account_id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "done -> open automation keeps working (regression guard)"
+    steps:
+      - step: "Create source analytic account of the contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_4"
+        values:
+          name: "Test Source AA - Open Guard Done Reopen 4"
+
+      - step: "Create draft PoB as admin"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_4"
+        as_user: "base.user_admin"
+        values:
+          title: "Test PoB - Open Guard Done Reopen 4"
+          source_analytic_account_id: "REC: source_aa_4.id"
+
+      - step: "Confirm the PoB"
+        action: "call"
+        target: "pob_4"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04).
+      - step: "PoB is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "pob_4"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the PoB reaches open"
+        action: "call"
+        target: "pob_4"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Move the PoB to done (simulates pob_open_2_done automation)"
+        action: "call"
+        target: "pob_4"
+        method: "action_done"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "Reopen from done (simulates pob_done_2_open automation)"
+        action: "call"
+        target: "pob_4"
+        method: "action_open"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"

--- a/ssi_revenue_recognition/tests/test_performance_obligation_open_guard.py
+++ b/ssi_revenue_recognition/tests/test_performance_obligation_open_guard.py
@@ -1,0 +1,22 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPerformanceObligationOpenGuard(YamlTransactionCase):
+    """Scenario tests for the ``action_open`` source-state guard.
+
+    Covers issue #74: ``_10_check_open_source_state`` must reject
+    ``action_open`` from any state other than ``confirm`` (the
+    approval flow) or ``done`` (the ``pob_done_2_open`` automation),
+    while leaving both of those two flows working end to end.
+    """
+
+    def test_performance_obligation_open_guard(self):
+        """Run the open source-state guard scenarios."""
+        self.run_yaml_scenario("test_data_performance_obligation_open_guard.yaml")


### PR DESCRIPTION
## Ringkasan

Menambahkan hook `@ssi_decorator.pre_open_check()` `_10_check_open_source_state`
pada `performance_obligation`: `action_open()` kini menolak dipanggil dari state
selain `confirm`/`done` dengan `UserError`, mencegah efek samping
`post_open_action` (pembuatan analytic account) berjalan pada dokumen yang
belum melalui alur approval maupun otomasi `done->open`.

Menambahkan skenario uji `odoo-yaml-test` (2 negatif, 2 positif) untuk penjaga
tersebut: penolakan dari `draft` dan dari `open`, regression guard alur
approval `draft->confirm->open`, dan regression guard otomasi `done->open`.

Tidak ada perubahan XML ID, nama class, nama field, atau nama method yang
sudah ada.

Closes open-synergy/ssi-revenue-recognition#74

## Test plan

- [x] Modul & unit-test validator: 0 error (dijalankan eksekusi sebelumnya)
- [ ] CI hijau