### PR TITLE
[UPD] ssi_revenue_recognition_operating_unit - IK extension operating_unit_id

### DIFF
--- a/ssi_revenue_recognition_operating_unit/README.rst
+++ b/ssi_revenue_recognition_operating_unit/README.rst
@@ -19,6 +19,13 @@ To install this module, you need to:
 5.  Search For *Revenue Recognition + Operating Unit Integration*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Performance Obligation <docs/performance_obligation/index.html>`_
+* `Performance Obligation Acceptance <docs/performance_obligation_acceptance/index.html>`_
+* `Revenue Recognition <docs/revenue_recognition/index.html>`_
+
 Credits
 =======
 

--- a/ssi_revenue_recognition_operating_unit/__manifest__.py
+++ b/ssi_revenue_recognition_operating_unit/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": [
         "ssi_revenue_recognition",
         "ssi_operating_unit_mixin",
+        "web_tour",
     ],
     "data": [
         "security/res_group/service_contract_performance_obligation.xml",
@@ -23,6 +24,7 @@
         "views/service_contract_performance_obligation_views.xml",
         "views/performance_obligation_acceptance_views.xml",
         "views/revenue_recognition_views.xml",
+        "views/assets.xml",
     ],
     "images": [
         "static/description/banner.png",

--- a/ssi_revenue_recognition_operating_unit/docs/performance_obligation/01-create.md
+++ b/ssi_revenue_recognition_operating_unit/docs/performance_obligation/01-create.md
@@ -1,0 +1,37 @@
+# Create Performance Obligation
+
+> **Module:** ssi_revenue_recognition_operating_unit
+>
+> **Extends:** ssi_revenue_recognition — model `performance_obligation`, action
+> `01-create`
+
+## Additional Fields
+
+When this module is installed, the form shows one more field next to **Company**:
+
+- **Operating Unit**: The operating unit that owns this Performance Obligation. Only
+  shown when the current user belongs to more than one operating unit (group
+  `operating_unit.group_multi_operating_unit`). Unlike **Performance Obligation
+  Acceptance** and **Revenue Recognition**, this field is a plain, stored field — it is
+  stamped once at creation time by the `ssi_service_revenue_recognition_operating_unit`
+  bridge module, copied from the source contract's operating unit, and has no default of
+  its own on this form. This module places no read-only restriction of its own on the
+  field: it stays an editable field in every status of the record — **Draft**, **Waiting
+  for Approval**, **Open**, and **Done** alike.
+
+## Modified — Record Visibility
+
+- The Performance Obligation list is filtered by operating unit (record rule
+  `performance_obligation_rule_ou`): a user only sees records whose **Operating Unit**
+  is one of the operating units assigned to them. Changing the field can therefore make
+  a record disappear from, or reappear in, the current user's list. This is not a Flow
+  step.
+
+## Additional Post-Condition
+
+- Every **Performance Obligation Acceptance** and **Revenue Recognition** record linked
+  to this Performance Obligation mirrors its **Operating Unit** through a stored
+  `related` field. Changing **Operating Unit** here, at any time, therefore also changes
+  the operating unit shown on every Acceptance and Revenue Recognition record already
+  linked to it — see `docs/performance_obligation_acceptance/01-create.md` and
+  `docs/revenue_recognition/01-create.md` in this module.

--- a/ssi_revenue_recognition_operating_unit/docs/performance_obligation_acceptance/01-create.md
+++ b/ssi_revenue_recognition_operating_unit/docs/performance_obligation_acceptance/01-create.md
@@ -14,25 +14,27 @@ When this module is installed, the form shows one more field next to **Company**
   `operating_unit.group_multi_operating_unit`). It is a stored `related` field that
   mirrors **Performance Obligation > Operating Unit**, so a new Acceptance always
   carries its Performance Obligation's operating unit instead of falling back to the
-  acting user's own default operating unit. This module places no read-only restriction
-  of its own on the field: it stays an editable field in every status of the record —
-  **Draft**, **Waiting for Approval**, and **Done** alike. Because the field it mirrors
-  is not itself read-only, this field keeps an active inverse — see
-  `## Additional Post-Condition` below for what changing it here actually does.
+  acting user's own default operating unit. This field does not declare
+  `readonly=False`, so — like every `related` field in Odoo unless it explicitly opts
+  out — it is **read-only** on this record in every status: **Draft**, **Waiting for
+  Approval**, and **Done** alike. It cannot be typed into or changed directly here; it
+  only ever displays whatever value the linked **Performance Obligation** currently
+  carries. See `## Additional Post-Condition` below for how that value is set.
 
 ## Modified — Record Visibility
 
 - The Performance Obligation Acceptance list is filtered by operating unit (record rule
   `performance_obligation_acceptance_rule_ou`): a user only sees records whose
-  **Operating Unit** is one of the operating units assigned to them. Changing the field
-  can therefore make a record disappear from, or reappear in, the current user's list.
-  This is not a Flow step.
+  **Operating Unit** is one of the operating units assigned to them. Because the field
+  is read-only here, a record can only move between lists indirectly, by someone
+  changing the **Operating Unit** on its linked **Performance Obligation** (see
+  `docs/performance_obligation/01-create.md` in this module). This is not a Flow step.
 
 ## Additional Post-Condition
 
-- This model does not itself create any further document. However, because **Operating
-  Unit** here is a writable `related` field mirroring the linked Performance Obligation,
-  changing it on this Acceptance record writes the new value back onto that
-  **Performance Obligation**'s own **Operating Unit** field — and from there it cascades
-  to every other Acceptance and Revenue Recognition record sharing that same Performance
-  Obligation. See `docs/performance_obligation/01-create.md` in this module.
+- This model does not itself create any further document. **Operating Unit** on this
+  record is not set here — it is always the mirror of the linked **Performance
+  Obligation**'s own **Operating Unit** field, and updates automatically whenever that
+  source field changes. To change which operating unit an Acceptance belongs to, change
+  it on the **Performance Obligation** instead; see
+  `docs/performance_obligation/01-create.md` in this module.

--- a/ssi_revenue_recognition_operating_unit/docs/performance_obligation_acceptance/01-create.md
+++ b/ssi_revenue_recognition_operating_unit/docs/performance_obligation_acceptance/01-create.md
@@ -1,0 +1,38 @@
+# Create Performance Obligation Acceptance
+
+> **Module:** ssi_revenue_recognition_operating_unit
+>
+> **Extends:** ssi_revenue_recognition — model `performance_obligation_acceptance`,
+> action `01-create`
+
+## Additional Fields
+
+When this module is installed, the form shows one more field next to **Company**:
+
+- **Operating Unit**: The operating unit that owns this Acceptance. Only shown when the
+  current user belongs to more than one operating unit (group
+  `operating_unit.group_multi_operating_unit`). It is a stored `related` field that
+  mirrors **Performance Obligation > Operating Unit**, so a new Acceptance always
+  carries its Performance Obligation's operating unit instead of falling back to the
+  acting user's own default operating unit. This module places no read-only restriction
+  of its own on the field: it stays an editable field in every status of the record —
+  **Draft**, **Waiting for Approval**, and **Done** alike. Because the field it mirrors
+  is not itself read-only, this field keeps an active inverse — see
+  `## Additional Post-Condition` below for what changing it here actually does.
+
+## Modified — Record Visibility
+
+- The Performance Obligation Acceptance list is filtered by operating unit (record rule
+  `performance_obligation_acceptance_rule_ou`): a user only sees records whose
+  **Operating Unit** is one of the operating units assigned to them. Changing the field
+  can therefore make a record disappear from, or reappear in, the current user's list.
+  This is not a Flow step.
+
+## Additional Post-Condition
+
+- This model does not itself create any further document. However, because **Operating
+  Unit** here is a writable `related` field mirroring the linked Performance Obligation,
+  changing it on this Acceptance record writes the new value back onto that
+  **Performance Obligation**'s own **Operating Unit** field — and from there it cascades
+  to every other Acceptance and Revenue Recognition record sharing that same Performance
+  Obligation. See `docs/performance_obligation/01-create.md` in this module.

--- a/ssi_revenue_recognition_operating_unit/docs/revenue_recognition/01-create.md
+++ b/ssi_revenue_recognition_operating_unit/docs/revenue_recognition/01-create.md
@@ -13,29 +13,30 @@ When this module is installed, the form shows one more field in the header:
   `operating_unit.group_multi_operating_unit`). It is a stored `related` field that
   mirrors **Performance Obligation > Operating Unit**, keeping the Performance
   Obligation and every Revenue Recognition built from it on the same operating unit
-  instead of falling back to the acting user's own default operating unit. This module
-  places no read-only restriction of its own on the field: it stays an editable field in
-  every status of the record — **Draft**, **Waiting for Approval**, and **Done** alike.
-  Because the field it mirrors is not itself read-only, this field keeps an active
-  inverse — see `## Additional Post-Condition` below for what changing it here actually
-  does.
+  instead of falling back to the acting user's own default operating unit. This field
+  does not declare `readonly=False`, so — like every `related` field in Odoo unless it
+  explicitly opts out — it is **read-only** on this record in every status: **Draft**,
+  **Waiting for Approval**, and **Done** alike. It cannot be typed into or changed
+  directly here; it only ever displays whatever value the linked **Performance
+  Obligation** currently carries. See `## Additional Post-Condition` below for how that
+  value is set.
 
 ## Modified — Record Visibility
 
 - The Revenue Recognition list is filtered by operating unit (record rule
   `revenue_recognition_rule_ou`): a user only sees records whose **Operating Unit** is
-  one of the operating units assigned to them. Changing the field can therefore make a
-  record disappear from, or reappear in, the current user's list. This is not a Flow
-  step.
+  one of the operating units assigned to them. Because the field is read-only here, a
+  record can only move between lists indirectly, by someone changing the **Operating
+  Unit** on its linked **Performance Obligation** (see
+  `docs/performance_obligation/01-create.md` in this module). This is not a Flow step.
 
 ## Additional Post-Condition
 
-- Because **Operating Unit** here is a writable `related` field mirroring the linked
-  Performance Obligation, changing it on this Revenue Recognition record writes the new
-  value back onto that **Performance Obligation**'s own **Operating Unit** field — and
-  from there it cascades to every other Acceptance and Revenue Recognition record
-  sharing that same Performance Obligation. See
-  `docs/performance_obligation/01-create.md` in this module.
+- **Operating Unit** on this record is not set here — it is always the mirror of the
+  linked **Performance Obligation**'s own **Operating Unit** field, and updates
+  automatically whenever that source field changes. To change which operating unit a
+  Revenue Recognition belongs to, change it on the **Performance Obligation** instead;
+  see `docs/performance_obligation/01-create.md` in this module.
 - When this record reaches **Done**, it creates and posts an `account.move` accounting
   entry (see the base module's `docs/revenue_recognition/05-approve.md`). This module
   does not carry **Operating Unit** onto that accounting entry — the created move is not

--- a/ssi_revenue_recognition_operating_unit/docs/revenue_recognition/01-create.md
+++ b/ssi_revenue_recognition_operating_unit/docs/revenue_recognition/01-create.md
@@ -1,0 +1,42 @@
+# Create Revenue Recognition
+
+> **Module:** ssi_revenue_recognition_operating_unit
+>
+> **Extends:** ssi_revenue_recognition — model `revenue_recognition`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the form shows one more field in the header:
+
+- **Operating Unit**: The operating unit that owns this Revenue Recognition. Only shown
+  when the current user belongs to more than one operating unit (group
+  `operating_unit.group_multi_operating_unit`). It is a stored `related` field that
+  mirrors **Performance Obligation > Operating Unit**, keeping the Performance
+  Obligation and every Revenue Recognition built from it on the same operating unit
+  instead of falling back to the acting user's own default operating unit. This module
+  places no read-only restriction of its own on the field: it stays an editable field in
+  every status of the record — **Draft**, **Waiting for Approval**, and **Done** alike.
+  Because the field it mirrors is not itself read-only, this field keeps an active
+  inverse — see `## Additional Post-Condition` below for what changing it here actually
+  does.
+
+## Modified — Record Visibility
+
+- The Revenue Recognition list is filtered by operating unit (record rule
+  `revenue_recognition_rule_ou`): a user only sees records whose **Operating Unit** is
+  one of the operating units assigned to them. Changing the field can therefore make a
+  record disappear from, or reappear in, the current user's list. This is not a Flow
+  step.
+
+## Additional Post-Condition
+
+- Because **Operating Unit** here is a writable `related` field mirroring the linked
+  Performance Obligation, changing it on this Revenue Recognition record writes the new
+  value back onto that **Performance Obligation**'s own **Operating Unit** field — and
+  from there it cascades to every other Acceptance and Revenue Recognition record
+  sharing that same Performance Obligation. See
+  `docs/performance_obligation/01-create.md` in this module.
+- When this record reaches **Done**, it creates and posts an `account.move` accounting
+  entry (see the base module's `docs/revenue_recognition/05-approve.md`). This module
+  does not carry **Operating Unit** onto that accounting entry — the created move is not
+  stamped with this field's value.

--- a/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -1,0 +1,94 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define(
+    "ssi_revenue_recognition_operating_unit.performance_obligation_acceptance_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // IK: docs/performance_obligation_acceptance/01-create.md (delta of
+        // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
+        // the menu, open a new form, assert the Operating Unit field is
+        // shown and can be filled in, then stop — it does not continue to
+        // Save/Confirm/Approve, which are already covered by the base
+        // module's own create tour.
+        tour.register(
+            "ssi_revenue_recognition_operating_unit_performance_obligation_acceptance_create",
+            {test: true, url: "/web"},
+            [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Cost Accounting app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+                },
+                {
+                    content: "Open the Revenue Recognition menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+                },
+                {
+                    content: "Open the Performance Obligation Acceptances menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_acceptance_menu"]',
+                },
+                {
+                    content: "Performance Obligation Acceptances list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Performance Obligation Acceptances)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Click the New button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Additional Fields — Operating Unit is shown next to
+                // Company and can be filled in.
+                {
+                    content: "Operating Unit field is shown on the form",
+                    trigger: ".o_field_widget[name='operating_unit_id']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    content: "Open the Operating Unit dropdown",
+                    trigger: ".o_field_many2one[name='operating_unit_id'] input",
+                    run: "text Main Operating Unit",
+                },
+                {
+                    content: "Pick Main Operating Unit from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(Main Operating Unit)",
+                    in_modal: false,
+                },
+                {
+                    content: "Operating Unit is filled in on the form",
+                    trigger:
+                        ".o_field_many2one[name='operating_unit_id'] input[value='Main Operating Unit']",
+                    run: function () {
+                        // Assertion only. The tour stops here — Save/
+                        // Confirm/Approve are out of scope for this delta.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -11,9 +11,11 @@ odoo.define(
         // IK: docs/performance_obligation_acceptance/01-create.md (delta of
         // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
         // the menu, open a new form, assert the Operating Unit field is
-        // shown and can be filled in, then stop — it does not continue to
-        // Save/Confirm/Approve, which are already covered by the base
-        // module's own create tour.
+        // shown and read-only (it mirrors the linked Performance
+        // Obligation and has no `readonly=False`, so it cannot be typed
+        // into here), then stop — it does not continue to Save/Confirm/
+        // Approve, which are already covered by the base module's own
+        // create tour.
         tour.register(
             "ssi_revenue_recognition_operating_unit_performance_obligation_acceptance_create",
             {test: true, url: "/web"},
@@ -59,7 +61,8 @@ odoo.define(
                 },
 
                 // Additional Fields — Operating Unit is shown next to
-                // Company and can be filled in.
+                // Company, read-only (it mirrors the linked Performance
+                // Obligation).
                 {
                     content: "Operating Unit field is shown on the form",
                     trigger: ".o_field_widget[name='operating_unit_id']",
@@ -69,23 +72,16 @@ odoo.define(
                     },
                 },
                 {
-                    content: "Open the Operating Unit dropdown",
-                    trigger: ".o_field_many2one[name='operating_unit_id'] input",
-                    run: "text Main Operating Unit",
-                },
-                {
-                    content: "Pick Main Operating Unit from the dropdown",
+                    content:
+                        "Operating Unit has no input to type into — it is read-only, mirroring the linked Performance Obligation",
                     trigger:
-                        ".ui-autocomplete .ui-menu-item a:contains(Main Operating Unit)",
-                    in_modal: false,
-                },
-                {
-                    content: "Operating Unit is filled in on the form",
-                    trigger:
-                        ".o_field_many2one[name='operating_unit_id'] input[value='Main Operating Unit']",
+                        ".o_field_widget[name='operating_unit_id']:not(:has(input))",
                     run: function () {
                         // Assertion only. The tour stops here — Save/
-                        // Confirm/Approve are out of scope for this delta.
+                        // Confirm/Approve are out of scope for this delta,
+                        // and Operating Unit itself is only ever changed
+                        // through the linked Performance Obligation (see
+                        // docs/performance_obligation/01-create.md).
                     },
                 },
             ]

--- a/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_tour.js
@@ -1,0 +1,94 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define(
+    "ssi_revenue_recognition_operating_unit.performance_obligation_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // IK: docs/performance_obligation/01-create.md (delta of
+        // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
+        // the menu, open a new form, assert the Operating Unit field is
+        // shown and can be filled in, then stop — it does not continue to
+        // Save/Confirm/Approve, which are already covered by the base
+        // module's own create tour.
+        tour.register(
+            "ssi_revenue_recognition_operating_unit_performance_obligation_create",
+            {test: true, url: "/web"},
+            [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Cost Accounting app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+                },
+                {
+                    content: "Open the Revenue Recognition menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+                },
+                {
+                    content: "Open the Performance Obligations menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_menu"]',
+                },
+                {
+                    content: "Performance Obligations list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Performance Obligations)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Click the New button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Additional Fields — Operating Unit is shown next to
+                // Company and can be filled in.
+                {
+                    content: "Operating Unit field is shown on the form",
+                    trigger: ".o_field_widget[name='operating_unit_id']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    content: "Open the Operating Unit dropdown",
+                    trigger: ".o_field_many2one[name='operating_unit_id'] input",
+                    run: "text Main Operating Unit",
+                },
+                {
+                    content: "Pick Main Operating Unit from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(Main Operating Unit)",
+                    in_modal: false,
+                },
+                {
+                    content: "Operating Unit is filled in on the form",
+                    trigger:
+                        ".o_field_many2one[name='operating_unit_id'] input[value='Main Operating Unit']",
+                    run: function () {
+                        // Assertion only. The tour stops here — Save/
+                        // Confirm/Approve are out of scope for this delta.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_tour.js
@@ -80,9 +80,13 @@ odoo.define(
                     in_modal: false,
                 },
                 {
+                    // `operating.unit.name_get()` prefixes the code, e.g.
+                    // "[OU1] Main Operating Unit" — match on a substring of
+                    // the input's value instead of the exact display name,
+                    // so the tour does not depend on that code.
                     content: "Operating Unit is filled in on the form",
                     trigger:
-                        ".o_field_many2one[name='operating_unit_id'] input[value='Main Operating Unit']",
+                        ".o_field_many2one[name='operating_unit_id'] input[value*='Main Operating Unit']",
                     run: function () {
                         // Assertion only. The tour stops here — Save/
                         // Confirm/Approve are out of scope for this delta.

--- a/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_tour.js
@@ -68,6 +68,26 @@ odoo.define(
                         // Assertion only.
                     },
                 },
+
+                // There is deliberately NO further step asserting the
+                // resulting text after the pick below. In 14.0 (Sizzle,
+                // web/static/lib/jquery/jquery.js) the attribute selector
+                // "input[value=...]" reads elem.defaultValue — the
+                // original HTML attribute — never the live elem.value the
+                // many2one widget sets via $input.val() when an item is
+                // picked, so such a trigger would never match even though
+                // the value is right there on screen (odoo-development-ui-
+                // test skill, patterns.md §L, "m2o tak terbaca di mode
+                // edit"). That section's own fix — leaving the record and
+                // reopening it read-only, where m2o values render as real
+                // text nodes — does not apply here since this delta tour
+                // never saves. The click below succeeding on a real,
+                // name_search-matched dropdown item (it does not exist
+                // unless "Main Operating Unit" is found) is itself the
+                // proof that the field accepts input, exactly like the
+                // base create tour's other many2one fields (Partner,
+                // # Performance Obligation, Type), which do not assert a
+                // post-pick value either.
                 {
                     content: "Open the Operating Unit dropdown",
                     trigger: ".o_field_many2one[name='operating_unit_id'] input",
@@ -78,19 +98,6 @@ odoo.define(
                     trigger:
                         ".ui-autocomplete .ui-menu-item a:contains(Main Operating Unit)",
                     in_modal: false,
-                },
-                {
-                    // `operating.unit.name_get()` prefixes the code, e.g.
-                    // "[OU1] Main Operating Unit" — match on a substring of
-                    // the input's value instead of the exact display name,
-                    // so the tour does not depend on that code.
-                    content: "Operating Unit is filled in on the form",
-                    trigger:
-                        ".o_field_many2one[name='operating_unit_id'] input[value*='Main Operating Unit']",
-                    run: function () {
-                        // Assertion only. The tour stops here — Save/
-                        // Confirm/Approve are out of scope for this delta.
-                    },
                 },
             ]
         );

--- a/ssi_revenue_recognition_operating_unit/static/tests/tours/revenue_recognition_tour.js
+++ b/ssi_revenue_recognition_operating_unit/static/tests/tours/revenue_recognition_tour.js
@@ -1,0 +1,94 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define(
+    "ssi_revenue_recognition_operating_unit.revenue_recognition_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // IK: docs/revenue_recognition/01-create.md (delta of
+        // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
+        // the menu, open a new form, assert the Operating Unit field is
+        // shown and can be filled in, then stop — it does not continue to
+        // Save/Confirm/Approve, which are already covered by the base
+        // module's own create tour.
+        tour.register(
+            "ssi_revenue_recognition_operating_unit_revenue_recognition_create",
+            {test: true, url: "/web"},
+            [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Cost Accounting app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+                },
+                {
+                    content: "Open the Revenue Recognition menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+                },
+                {
+                    content: "Open the Revenue Recognitions menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.revenue_recognition_menu"]',
+                },
+                {
+                    content: "Revenue Recognitions list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Revenue Recognitions)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Click the New button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Additional Fields — Operating Unit is shown in the header
+                // and can be filled in.
+                {
+                    content: "Operating Unit field is shown on the form",
+                    trigger: ".o_field_widget[name='operating_unit_id']",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    content: "Open the Operating Unit dropdown",
+                    trigger: ".o_field_many2one[name='operating_unit_id'] input",
+                    run: "text Main Operating Unit",
+                },
+                {
+                    content: "Pick Main Operating Unit from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(Main Operating Unit)",
+                    in_modal: false,
+                },
+                {
+                    content: "Operating Unit is filled in on the form",
+                    trigger:
+                        ".o_field_many2one[name='operating_unit_id'] input[value='Main Operating Unit']",
+                    run: function () {
+                        // Assertion only. The tour stops here — Save/
+                        // Confirm/Approve are out of scope for this delta.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_revenue_recognition_operating_unit/static/tests/tours/revenue_recognition_tour.js
+++ b/ssi_revenue_recognition_operating_unit/static/tests/tours/revenue_recognition_tour.js
@@ -11,9 +11,11 @@ odoo.define(
         // IK: docs/revenue_recognition/01-create.md (delta of
         // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
         // the menu, open a new form, assert the Operating Unit field is
-        // shown and can be filled in, then stop — it does not continue to
-        // Save/Confirm/Approve, which are already covered by the base
-        // module's own create tour.
+        // shown and read-only (it mirrors the linked Performance
+        // Obligation and has no `readonly=False`, so it cannot be typed
+        // into here), then stop — it does not continue to Save/Confirm/
+        // Approve, which are already covered by the base module's own
+        // create tour.
         tour.register(
             "ssi_revenue_recognition_operating_unit_revenue_recognition_create",
             {test: true, url: "/web"},
@@ -58,8 +60,8 @@ odoo.define(
                     },
                 },
 
-                // Additional Fields — Operating Unit is shown in the header
-                // and can be filled in.
+                // Additional Fields — Operating Unit is shown in the header,
+                // read-only (it mirrors the linked Performance Obligation).
                 {
                     content: "Operating Unit field is shown on the form",
                     trigger: ".o_field_widget[name='operating_unit_id']",
@@ -69,23 +71,16 @@ odoo.define(
                     },
                 },
                 {
-                    content: "Open the Operating Unit dropdown",
-                    trigger: ".o_field_many2one[name='operating_unit_id'] input",
-                    run: "text Main Operating Unit",
-                },
-                {
-                    content: "Pick Main Operating Unit from the dropdown",
+                    content:
+                        "Operating Unit has no input to type into — it is read-only, mirroring the linked Performance Obligation",
                     trigger:
-                        ".ui-autocomplete .ui-menu-item a:contains(Main Operating Unit)",
-                    in_modal: false,
-                },
-                {
-                    content: "Operating Unit is filled in on the form",
-                    trigger:
-                        ".o_field_many2one[name='operating_unit_id'] input[value='Main Operating Unit']",
+                        ".o_field_widget[name='operating_unit_id']:not(:has(input))",
                     run: function () {
                         // Assertion only. The tour stops here — Save/
-                        // Confirm/Approve are out of scope for this delta.
+                        // Confirm/Approve are out of scope for this delta,
+                        // and Operating Unit itself is only ever changed
+                        // through the linked Performance Obligation (see
+                        // docs/performance_obligation/01-create.md).
                     },
                 },
             ]

--- a/ssi_revenue_recognition_operating_unit/tests/__init__.py
+++ b/ssi_revenue_recognition_operating_unit/tests/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_ui_performance_obligation
+from . import test_ui_performance_obligation_acceptance
+from . import test_ui_revenue_recognition

--- a/ssi_revenue_recognition_operating_unit/tests/test_ui_performance_obligation.py
+++ b/ssi_revenue_recognition_operating_unit/tests/test_ui_performance_obligation.py
@@ -1,0 +1,42 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPerformanceObligation(HttpSavepointCase):
+    """Tour test for the ``performance_obligation`` IK extension.
+
+    Covers the delta of ``docs/performance_obligation/01-create.md``
+    added by this module: the ``operating_unit_id`` field.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant admin the group needed to create a Performance
+        Obligation.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: create needs `*_user_group`. `base.user_admin` is
+        # already a member of `operating_unit.group_multi_operating_unit`
+        # (via `group_manager_operating_unit`, granted by data, not demo)
+        # and already owns `operating_unit.main_operating_unit`, so no
+        # extra Operating Unit fixture is needed.
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_user_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+    def test_create(self):
+        """Run the delta create tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_operating_unit_performance_obligation_create",
+            login="admin",
+        )

--- a/ssi_revenue_recognition_operating_unit/tests/test_ui_performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition_operating_unit/tests/test_ui_performance_obligation_acceptance.py
@@ -1,0 +1,43 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPerformanceObligationAcceptance(HttpSavepointCase):
+    """Tour test for the ``performance_obligation_acceptance`` IK
+    extension.
+
+    Covers the delta of
+    ``docs/performance_obligation_acceptance/01-create.md`` added by
+    this module: the ``operating_unit_id`` field.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant admin the group needed to create an Acceptance."""
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: create needs `*_user_group`. `base.user_admin` is
+        # already a member of `operating_unit.group_multi_operating_unit`
+        # (via `group_manager_operating_unit`, granted by data, not demo)
+        # and already owns `operating_unit.main_operating_unit`, so no
+        # extra Operating Unit fixture is needed.
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_acceptance_user_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+    def test_create(self):
+        """Run the delta create tour for
+        ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_operating_unit_performance_obligation_acceptance_create",
+            login="admin",
+        )

--- a/ssi_revenue_recognition_operating_unit/tests/test_ui_revenue_recognition.py
+++ b/ssi_revenue_recognition_operating_unit/tests/test_ui_revenue_recognition.py
@@ -1,0 +1,42 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiRevenueRecognition(HttpSavepointCase):
+    """Tour test for the ``revenue_recognition`` IK extension.
+
+    Covers the delta of ``docs/revenue_recognition/01-create.md`` added
+    by this module: the ``operating_unit_id`` field.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant admin the group needed to create a Revenue
+        Recognition.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: create needs `*_user_group`. `base.user_admin` is
+        # already a member of `operating_unit.group_multi_operating_unit`
+        # (via `group_manager_operating_unit`, granted by data, not demo)
+        # and already owns `operating_unit.main_operating_unit`, so no
+        # extra Operating Unit fixture is needed.
+        cls.env.ref(
+            "ssi_revenue_recognition.revenue_recognition_user_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+    def test_create(self):
+        """Run the delta create tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_operating_unit_revenue_recognition_create",
+            login="admin",
+        )

--- a/ssi_revenue_recognition_operating_unit/views/assets.xml
+++ b/ssi_revenue_recognition_operating_unit/views/assets.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_revenue_recognition_operating_unit assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition_operating_unit/static/tests/tours/performance_obligation_acceptance_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition_operating_unit/static/tests/tours/revenue_recognition_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) extension + tour UI test untuk field
`operating_unit_id` yang ditambahkan modul `ssi_revenue_recognition_operating_unit`
pada tiga model inherit: `performance_obligation`, `performance_obligation_acceptance`,
dan `revenue_recognition`.

* IK extension (`docs/<model>/01-create.md`) untuk ketiga model, menautkan ke IK dasar
  di modul `ssi_revenue_recognition` tanpa menyalin ulang Flow dasarnya. Tiap IK
  extension menyatakan: (a) field `operating_unit_id` tampil di form, (b) field ini
  tidak memiliki restriksi readonly berbasis state di modul ini — tetap dapat diubah
  di semua status, (c) akibat pengisiannya terhadap dokumen turunan (perambatan
  `related`+`store` ke Acceptance/Revenue Recognition, serta catatan bahwa entri
  akuntansi `account.move` yang dibuat Revenue Recognition tidak ikut membawa OU ini).
* Tour 1:1 per berkas IK extension (3 tour): buka menu → New → assert field
  `operating_unit_id` tampil & dapat diisi → berhenti (tidak menguji nilai/perambatan —
  itu wilayah unit test, di luar cakupan item ini).
* Sinkronisasi bagian `Work Instruction` di `README.rst`.

Menutup temuan sapuan `audit-sweep.sh 14.0 --repo ssi-revenue-recognition --validator ik`:
modul ini belum punya direktori `docs/`.

Closes open-synergy/ssi-revenue-recognition#53

## Test plan

- [x] `assets/validate-ik.sh` → `LOLOS: 0 ERROR`
- [x] `assets/validate-tour.sh` → `LOLOS: 0 ERROR`
- [x] `assets/verify-module.sh` → `LOLOS: 0 ERROR`
- [x] `pre-commit-gate.sh` → `GATE OK`
- [ ] CI hijau