### PR TITLE
[UPD] ssi_revenue_recognition_project - IK extension, tour & bugfix create-project

### DIFF
--- a/ssi_revenue_recognition_project/README.rst
+++ b/ssi_revenue_recognition_project/README.rst
@@ -20,6 +20,11 @@ To install this module, you need to:
 5.  Search For *Revenue Recognition + Project Integration*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Approve Performance Obligation <docs/performance_obligation/05-approve.html>`_
+
 Credits
 =======
 

--- a/ssi_revenue_recognition_project/__manifest__.py
+++ b/ssi_revenue_recognition_project/__manifest__.py
@@ -12,9 +12,11 @@
     "depends": [
         "ssi_revenue_recognition",
         "ssi_project",
+        "web_tour",
     ],
     "data": [
         "views/service_contract_performance_obligation_views.xml",
+        "views/assets.xml",
     ],
     "images": [
         "static/description/banner.png",

--- a/ssi_revenue_recognition_project/docs/performance_obligation/05-approve.md
+++ b/ssi_revenue_recognition_project/docs/performance_obligation/05-approve.md
@@ -1,0 +1,16 @@
+# Approve Performance Obligation
+
+> **Module:** ssi_revenue_recognition_project
+>
+> **Extends:** ssi_revenue_recognition — model `performance_obligation`, aksi
+> `05-approve`
+
+## Additional Post-Condition
+
+- When **Auto Create Project** is checked, a `project.project` record is automatically
+  created and linked via **Project** once the PoB reaches **Open** (`open`) — unless
+  **Project** was already set, in which case that existing project is refreshed instead.
+  When **Auto Create Project** is left unchecked (the default), this side effect does
+  not run and **Project** stays empty. This is not a Flow step; it runs automatically as
+  part of the same Approve action documented in the base module's
+  `ssi_revenue_recognition/docs/performance_obligation/05-approve.md`.

--- a/ssi_revenue_recognition_project/models/performance_obligation.py
+++ b/ssi_revenue_recognition_project/models/performance_obligation.py
@@ -66,13 +66,12 @@ class PerformanceObligation(models.Model):
         ``_01_create_project``.
 
         :return: dict of ``project.project`` values (``name``,
-            ``code``, ``analytic_account_id``, ``partner_id``,
-            ``date_start``, ``date``)
+            ``analytic_account_id``, ``partner_id``, ``date_start``,
+            ``date``)
         """
         self.ensure_one()
         return {
             "name": self.title,
-            "code": self.name,
             "analytic_account_id": self.analytic_account_id.id,
             "partner_id": self.partner_id.id,
             "date_start": self.date_start,

--- a/ssi_revenue_recognition_project/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_revenue_recognition_project/static/tests/tours/performance_obligation_tour.js
@@ -1,0 +1,120 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_revenue_recognition_project.performance_obligation_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/performance_obligation/05-approve.md (delta of
+    // ssi_revenue_recognition_project -- Additional Post-Condition).
+    // Navigation is scaffolded from the base module's own
+    // "05-approve" tour Flow (ssi_revenue_recognition); the only
+    // new assertion is the delta's Post-Condition: the Project
+    // field is filled once the record reaches Open. It does not
+    // open the linked project record or inspect any of its own
+    // fields -- that is unit test territory.
+    tour.register(
+        "ssi_revenue_recognition_project_performance_obligation_approve",
+        {test: true, url: "/web"},
+        [
+            // Base Flow 1 -- Open the Cost Accounting > Revenue
+            // Recognition > Performance Obligations menu.
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Revenue Recognition menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+            },
+            {
+                content: "Open the Performance Obligations menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_menu"]',
+            },
+            {
+                content: "Performance Obligations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Performance Obligations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Base Flow 2 -- Open the record to approve.
+            {
+                content: "Open the record",
+                trigger:
+                    ".o_data_row:contains(TOUR-POB-PROJECT-APPROVE) .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Base Flow 3 -- Click the Approve button.
+            {
+                content: "Click the Approve button",
+                trigger: ".o_statusbar_buttons button[name='action_approve_approval']",
+                extra_trigger: ".o_form_view",
+            },
+
+            // Base Flow 4 -- Click OK on the confirmation dialog.
+            {
+                content: "Confirm the dialog",
+                trigger: ".modal-footer button.btn-primary",
+                in_modal: true,
+            },
+
+            // Base Post-Condition -- the single approval level is
+            // fulfilled, so the record is auto-opened (action_open).
+            {
+                content: "Status is Open",
+                trigger:
+                    ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Delta Additional Post-Condition (docs/performance_obligation/
+            // 05-approve.md) -- the Project tab (added by this
+            // module) must be opened before its fields can be
+            // inspected; notebook panes outside the active tab stay
+            // hidden until clicked (patterns.md).
+            {
+                content: "Open the Project tab",
+                trigger: ".o_notebook .nav-link:contains(Project)",
+            },
+
+            // Auto Create Project was checked on this record, so
+            // opening the PoB also created a project.project record
+            // and linked it through Project. Anchored on the known
+            // fixture title -- also used as the created project's
+            // own name (see _prepare_project_data) -- so the trigger
+            // only matches once the field actually holds a value: an
+            // empty readonly many2one collapses to a zero-size box
+            // and jQuery's `:visible` never matches it (see the UI
+            // test skill's patterns.md).
+            {
+                content: "Project field shows the auto-created project",
+                trigger:
+                    ".o_field_widget[name='project_id']:contains(TOUR-POB-PROJECT-APPROVE)",
+                run: function () {
+                    // Assertion only; do not open the linked
+                    // project record.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_revenue_recognition_project/tests/__init__.py
+++ b/ssi_revenue_recognition_project/tests/__init__.py
@@ -2,4 +2,5 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import test_performance_obligation
 from . import test_ui_performance_obligation

--- a/ssi_revenue_recognition_project/tests/__init__.py
+++ b/ssi_revenue_recognition_project/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_ui_performance_obligation

--- a/ssi_revenue_recognition_project/tests/test_data_performance_obligation.yaml
+++ b/ssi_revenue_recognition_project/tests/test_data_performance_obligation.yaml
@@ -1,0 +1,151 @@
+scenarios:
+  - name: "Opening a PoB with auto_create_project creates a linked project"
+    steps:
+      - step: "Create source analytic account with a partner"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_1"
+        values:
+          name: "Test Source AA - Auto Create Project 1"
+          partner_id: "REF: base.res_partner_2"
+
+      - step: "Create the PoB's own analytic account"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "pob_aa_1"
+        values:
+          name: "Test PoB AA - Auto Create Project 1"
+
+      - step: "Create draft PoB with auto_create_project enabled"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_1"
+        as_user: "base.user_admin"
+        values:
+          title: "Test PoB - Auto Create Project 1"
+          source_analytic_account_id: "REC: source_aa_1.id"
+          analytic_account_id: "REC: pob_aa_1.id"
+          auto_create_project: true
+          date_start: 2026-01-01
+          date_end: 2026-12-31
+
+      - step: "PoB has no project yet"
+        action: "assert"
+        target: "pob_1"
+        asserts:
+          project_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Confirm the PoB"
+        action: "call"
+        target: "pob_1"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04) -- tanpa
+      # step ini approve_ok bisa terbaca dari cache yang diisi
+      # action_confirm, saat approval.approval belum ada.
+      - step: "PoB is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "pob_1"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the PoB (auto-runs action_open, no ValueError)"
+        action: "call"
+        target: "pob_1"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "A project.project was created and linked to the PoB"
+        action: "assert"
+        target: "pob_1"
+        asserts:
+          project_id:
+            type: "value"
+            operator: "is_truthy"
+          project_id.name:
+            type: "value"
+            expected: "Test PoB - Auto Create Project 1"
+          project_id.analytic_account_id:
+            type: "m2o"
+            expected: "REC: pob_aa_1"
+          project_id.partner_id:
+            type: "m2o"
+            expected_xml_id: "base.res_partner_2"
+          project_id.date_start:
+            type: "value"
+            expected: 2026-01-01
+          project_id.date:
+            type: "value"
+            expected: 2026-12-31
+
+  - name: "Opening a PoB without auto_create_project creates no project"
+    steps:
+      - step: "Create source analytic account with a partner"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_2"
+        values:
+          name: "Test Source AA - Auto Create Project 2"
+          partner_id: "REF: base.res_partner_2"
+
+      - step: "Create draft PoB with auto_create_project disabled"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_2"
+        as_user: "base.user_admin"
+        values:
+          title: "Test PoB - Auto Create Project 2"
+          source_analytic_account_id: "REC: source_aa_2.id"
+          auto_create_project: false
+
+      - step: "Confirm the PoB"
+        action: "call"
+        target: "pob_2"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04).
+      - step: "PoB is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "pob_2"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the PoB reaches open with no project created"
+        action: "call"
+        target: "pob_2"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "PoB still owns no project"
+        action: "assert"
+        target: "pob_2"
+        asserts:
+          project_id:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_revenue_recognition_project/tests/test_performance_obligation.py
+++ b/ssi_revenue_recognition_project/tests/test_performance_obligation.py
@@ -1,0 +1,22 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPerformanceObligation(YamlTransactionCase):
+    """Scenario tests for PoB-driven ``project.project`` provisioning.
+
+    Covers ``_01_create_project`` (``post_open_action`` hook): opening a
+    PoB with ``auto_create_project`` enabled must create a
+    ``project.project`` without sending the invalid ``code`` key, and
+    opening a PoB with it disabled must not create any project.
+    """
+
+    def test_performance_obligation(self):
+        """Run the PoB auto-create-project scenarios."""
+        self.run_yaml_scenario("test_data_performance_obligation.yaml")

--- a/ssi_revenue_recognition_project/tests/test_ui_performance_obligation.py
+++ b/ssi_revenue_recognition_project/tests/test_ui_performance_obligation.py
@@ -1,0 +1,57 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase -- NOT HttpCase. 14.0's plain HttpCase does not set
+# up cls.env in setUpClass, so the Pre-Condition fixture below would
+# fail with AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPerformanceObligation(HttpSavepointCase):
+    """Tour tests for the ``performance_obligation`` auto project delta."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a PoB pending approval, with Auto Create Project on.
+
+        Pre-Condition of the approve delta tour: the record must be in
+        the ``confirm`` state (Waiting for Approval) and the ``admin``
+        user (who runs the tour) must be a registered approver --
+        both requirements inherited from the base module's own
+        ``05-approve.md`` Pre-Condition. ``auto_create_project`` is set
+        so the delta's side effect (docs/performance_obligation/
+        05-approve.md) actually runs once the record is approved.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_validator_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+        AA = cls.env["account.analytic.account"]
+        cls.source_aa = AA.create({"name": "TOUR-POB-PROJECT-SOURCE-AA"})
+
+        Pob = cls.env["performance_obligation"]
+        cls.pob_approve = Pob.create(
+            {
+                "title": "TOUR-POB-PROJECT-APPROVE",
+                "source_analytic_account_id": cls.source_aa.id,
+                "user_id": cls.admin.id,
+                "auto_create_project": True,
+            }
+        )
+        cls.pob_approve.action_confirm()
+        cls.pob_approve.invalidate_cache()
+
+    def test_approve_creates_project(self):
+        """Run the approve delta tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_project_performance_obligation_approve",
+            login="admin",
+        )

--- a/ssi_revenue_recognition_project/views/assets.xml
+++ b/ssi_revenue_recognition_project/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_revenue_recognition_project assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition_project/static/tests/tours/performance_obligation_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Summary

- Menambahkan IK extension `docs/performance_obligation/05-approve.md` di modul
  `ssi_revenue_recognition_project` yang mendokumentasikan efek samping hook
  `_01_create_project` (`post_open_action`): saat **Auto Create Project** dicentang,
  membuka Performance Obligation otomatis membuat/menautkan record `project.project`
  lewat field **Project**. IK ini menautkan ke IK dasar `performance_obligation` di
  modul `ssi_revenue_recognition` (issue #51), tanpa menyalin ulang Flow dasarnya.
- Menambahkan tour pasangan 1:1 dari Flow IK dasar `05-approve` ditambah satu
  assertion delta, beserta pendaftaran aset `web.assets_tests` dan `HttpCase`
  pemanggilnya. Tour berhenti setelah status berubah menjadi **Open** dan field
  **Project** tampil terisi — tanpa memeriksa isi record project yang terbentuk
  (wilayah unit test terpisah).
- Menyinkronkan bagian **Work Instruction** di `README.rst`.
- **Bugfix (issue #78, ditemukan oleh tour di atas):** `_prepare_project_data()`
  mengirim key `code` yang tidak valid di model `project.project`, membuat
  `_01_create_project` selalu gagal dengan `ValueError` setiap kali PoB dengan
  `auto_create_project=True` dibuka. Key itu dihapus, docstring diperbarui, dan
  ditambahkan unit test YAML yang menguji skenario `auto_create_project` True/False.

Tidak ada perubahan field/view/security; satu bugfix Python minimal (hapus satu key
dict) plus docs + tour + test.

## Test plan

- [x] `assets/verify-module.sh` — `LOLOS: 0 ERROR`
- [x] `assets/validate-ik.sh` (skill `odoo-development-instruksi-kerja`) — `LOLOS: 0 ERROR`
- [x] `assets/validate-tour.sh` (skill `odoo-development-ui-test`) — `LOLOS: 0 ERROR`
- [x] `pre-commit-gate.sh` — `GATE OK` (6 pemeriksaan, 0 pelanggaran baru)
- [ ] CI GitHub Actions hijau

Closes #54
Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
