### PR TITLE
[UPD] ssi_revenue_recognition_work_log

### DIFF
--- a/ssi_revenue_recognition_work_log/README.rst
+++ b/ssi_revenue_recognition_work_log/README.rst
@@ -20,6 +20,13 @@ To install this module, you need to:
 5.  Search For *Revenue Recognition - Work Log Integration*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Performance Obligation <docs/performance_obligation/index.html>`_
+* `Performance Obligation Acceptance <docs/performance_obligation_acceptance/index.html>`_
+* `Revenue Recognition <docs/revenue_recognition/index.html>`_
+
 Credits
 =======
 

--- a/ssi_revenue_recognition_work_log/__manifest__.py
+++ b/ssi_revenue_recognition_work_log/__manifest__.py
@@ -11,9 +11,11 @@
     "depends": [
         "ssi_revenue_recognition",
         "ssi_work_log_mixin",
+        "web_tour",
     ],
     "data": [
         "views/performance_obligation_acceptance_views.xml",
+        "views/assets.xml",
     ],
     "demo": [],
     "images": [],

--- a/ssi_revenue_recognition_work_log/docs/performance_obligation/01-create.md
+++ b/ssi_revenue_recognition_work_log/docs/performance_obligation/01-create.md
@@ -1,0 +1,20 @@
+# Create Performance Obligation
+
+> **Module:** ssi_revenue_recognition_work_log
+>
+> **Extends:** ssi_revenue_recognition — model `performance_obligation`, action
+> `01-create`
+
+## Modified Flow
+
+- Anchor: visible on the form from the moment it opens (before step 3 of the base Flow),
+  and present in every status afterward — a **Work Log** tab is added by this module
+  (`mixin.work_object`). It holds:
+  - **Work Log Analytic Account**: an editable field to pick the analytic account work
+    logs on this PoB are expected to be booked against. Optional, no default.
+  - **Estimation**: an editable hour figure for the work planned on this PoB.
+  - An editable **Work Logs** list — `hr.work_log` lines linked to this PoB. Lines can
+    be added, edited, and removed directly on this tab, in any status.
+  - Read-only **Total**, **Remaining**, and **Excess** figures, kept in sync with the
+    **Work Logs** list against **Estimation**. This module does not document how the
+    figures are derived — see the model's docstring for that detail.

--- a/ssi_revenue_recognition_work_log/docs/performance_obligation_acceptance/01-create.md
+++ b/ssi_revenue_recognition_work_log/docs/performance_obligation_acceptance/01-create.md
@@ -1,0 +1,29 @@
+# Create Performance Obligation Acceptance
+
+> **Module:** ssi_revenue_recognition_work_log
+>
+> **Extends:** ssi_revenue_recognition — model `performance_obligation_acceptance`,
+> action `01-create`
+
+## Modified Flow
+
+- Anchor: visible on the form from the moment it opens (before step 3 of the base Flow),
+  and present in every status afterward — two tabs are added by this module.
+
+- **Work Log** tab (`mixin.work_object`) — the same tab this module adds to
+  **Performance Obligation** and **Revenue Recognition**; see
+  `docs/performance_obligation/01-create.md` in this module. It holds an editable **Work
+  Log Analytic Account**, an editable **Estimation**, an editable **Work Logs** list
+  (`hr.work_log` lines linked to this Acceptance), and read-only
+  **Total**/**Remaining**/**Excess** figures kept in sync with that list against
+  **Estimation**.
+
+- **Fullfilment Work Logs** tab — this tab is specific to Acceptance:
+  - It shows an editable **Work Logs** list, but the work logs offered for selection are
+    restricted to the set computed in `allowed_work_log_ids`: only `hr.work_log` records
+    booked against the linked Performance Obligation's analytic account, dated within
+    this Acceptance's **Date Start**/**Date End** window, and in status **Done**, can be
+    picked here.
+  - Selecting or removing lines automatically updates **Work Qty**, a read-only field on
+    the same tab, to reflect the lines currently selected. This module does not document
+    how the figure is derived — see the model's docstring for that detail.

--- a/ssi_revenue_recognition_work_log/docs/revenue_recognition/01-create.md
+++ b/ssi_revenue_recognition_work_log/docs/revenue_recognition/01-create.md
@@ -1,0 +1,19 @@
+# Create Revenue Recognition
+
+> **Module:** ssi_revenue_recognition_work_log
+>
+> **Extends:** ssi_revenue_recognition — model `revenue_recognition`, action `01-create`
+
+## Modified Flow
+
+- Anchor: visible on the form from the moment it opens (before step 3 of the base Flow),
+  and present in every status afterward — a **Work Log** tab is added by this module
+  (`mixin.work_object`). It holds:
+  - **Work Log Analytic Account**: an editable field to pick the analytic account work
+    logs on this record are expected to be booked against. Optional, no default.
+  - **Estimation**: an editable hour figure for the work planned on this record.
+  - An editable **Work Logs** list — `hr.work_log` lines linked to this record. Lines
+    can be added, edited, and removed directly on this tab, in any status.
+  - Read-only **Total**, **Remaining**, and **Excess** figures, kept in sync with the
+    **Work Logs** list against **Estimation**. This module does not document how the
+    figures are derived — see the model's docstring for that detail.

--- a/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -147,19 +147,22 @@ odoo.define(
                     trigger:
                         ".o_field_widget[name='poa_work_log_ids'] .o_field_x2many_list_row_add a",
                 },
-                // The SelectCreateDialog's list view is populated by its
-                // own `search_read` RPC after the modal opens, which can
-                // run past the default 10s step timeout under CI load —
-                // this is not a logic/filter bug (allowed_work_log_ids'
-                // domain is already correct by the time it resolves).
-                // Give this step more time to poll for the row instead
-                // of shortening what it asserts (`timeout`, tour-14.md
-                // §2 "Key step" — supported per-step override, default
-                // 10000ms).
+                // No leading ".modal " on these two triggers: while a
+                // modal is visible, tour_manager.js (`$modal_displayed
+                // .find(tip.trigger)`, web_tour/static/src/js/
+                // tour_manager.js) already scopes the search to inside
+                // that modal. A trigger starting with ".modal" would
+                // instead require a NESTED ".modal" descendant of the
+                // modal, which never exists — that selector can never
+                // match, at any timeout, which is exactly what CI showed
+                // (still failing at the same step after the timeout was
+                // raised to 30s: not a rendering race, a structurally
+                // unmatchable selector). Kept `timeout: 30000` anyway as
+                // a reasonable margin for the dialog's own `search_read`
+                // RPC under CI load.
                 {
                     content: "The allowed work log is offered in the dialog",
-                    trigger:
-                        ".modal .o_list_view .o_data_row:contains(TOUR-POBAWL-WORKLOG-1)",
+                    trigger: ".o_list_view .o_data_row:contains(TOUR-POBAWL-WORKLOG-1)",
                     timeout: 30000,
                     run: function () {
                         // Assertion only.
@@ -168,7 +171,7 @@ odoo.define(
                 {
                     content: "Select the allowed work log's row",
                     trigger:
-                        ".modal .o_list_view .o_data_row:contains(TOUR-POBAWL-WORKLOG-1) .o_list_record_selector input",
+                        ".o_list_view .o_data_row:contains(TOUR-POBAWL-WORKLOG-1) .o_list_record_selector input",
                 },
                 {
                     content: "Confirm the selection",

--- a/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -147,10 +147,20 @@ odoo.define(
                     trigger:
                         ".o_field_widget[name='poa_work_log_ids'] .o_field_x2many_list_row_add a",
                 },
+                // The SelectCreateDialog's list view is populated by its
+                // own `search_read` RPC after the modal opens, which can
+                // run past the default 10s step timeout under CI load —
+                // this is not a logic/filter bug (allowed_work_log_ids'
+                // domain is already correct by the time it resolves).
+                // Give this step more time to poll for the row instead
+                // of shortening what it asserts (`timeout`, tour-14.md
+                // §2 "Key step" — supported per-step override, default
+                // 10000ms).
                 {
                     content: "The allowed work log is offered in the dialog",
                     trigger:
                         ".modal .o_list_view .o_data_row:contains(TOUR-POBAWL-WORKLOG-1)",
+                    timeout: 30000,
                     run: function () {
                         // Assertion only.
                     },

--- a/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -104,9 +104,15 @@ odoo.define(
                 // Performance Obligation and Revenue Recognition; see
                 // docs/performance_obligation/01-create.md in this
                 // module).
+                // ":not(:contains(Fullfilment))" excludes the
+                // "Fullfilment Work Logs" tab added below — its label
+                // also contains the substring "Work Log", so the plain
+                // ":contains(Work Log)" selector matches both tabs and
+                // the tour's default click can land on either one.
                 {
                     content: "Work Log tab is displayed",
-                    trigger: ".o_notebook .nav-link:contains(Work Log)",
+                    trigger:
+                        ".o_notebook .nav-link:contains(Work Log):not(:contains(Fullfilment))",
                     extra_trigger: ".o_form_view.o_form_editable",
                 },
                 {

--- a/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_acceptance_tour.js
+++ b/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_acceptance_tour.js
@@ -1,0 +1,178 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define(
+    "ssi_revenue_recognition_work_log.performance_obligation_acceptance_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // IK: docs/performance_obligation_acceptance/01-create.md (delta of
+        // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
+        // the menu, open a new form, fill in just enough of the base Flow
+        // (Partner / # Performance Obligation / Date Start / Date End) for
+        // `allowed_work_log_ids` to have something to offer, then assert
+        // both added tabs — Work Log and Fulfillment Work Logs — and that
+        // a work log within the allowed set can actually be picked. It
+        // does not continue to Save/Confirm/Approve, which are already
+        // covered by the base module's own create tour, and it does not
+        // assert `qty_work_log`'s resulting value, which is unit test
+        // territory.
+        tour.register(
+            "ssi_revenue_recognition_work_log_performance_obligation_acceptance_create",
+            {test: true, url: "/web"},
+            [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Cost Accounting app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+                },
+                {
+                    content: "Open the Revenue Recognition menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+                },
+                {
+                    content: "Open the Performance Obligation Acceptances menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_acceptance_menu"]',
+                },
+                {
+                    content: "Performance Obligation Acceptances list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Performance Obligation Acceptances)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Click the New button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Base Flow 3 (partial) — just enough for
+                // `allowed_work_log_ids` to be computed.
+                {
+                    content: "Select the Partner",
+                    trigger: ".o_field_many2one[name='partner_id'] input",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                    run: "text TOUR-POBAWL-PARTNER",
+                },
+                {
+                    content: "Pick the Partner from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(TOUR-POBAWL-PARTNER)",
+                    in_modal: false,
+                },
+                {
+                    content: "Select the # Performance Obligation",
+                    trigger:
+                        ".o_field_many2one[name='performance_obligation_id'] input",
+                    run: "text PB-TOUR-POBAWL-1",
+                },
+                {
+                    content: "Pick the PoB from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(PB-TOUR-POBAWL-1)",
+                    in_modal: false,
+                },
+                {
+                    content: "Fill in Date Start",
+                    trigger: ".o_field_widget[name='date_start'] input",
+                    run: "text 01/01/2026",
+                },
+                {
+                    content: "Fill in Date End",
+                    trigger: ".o_field_widget[name='date_end'] input",
+                    run: "text 01/31/2026",
+                },
+
+                // Modified Flow — the Work Log tab (shared with
+                // Performance Obligation and Revenue Recognition; see
+                // docs/performance_obligation/01-create.md in this
+                // module).
+                {
+                    content: "Work Log tab is displayed",
+                    trigger: ".o_notebook .nav-link:contains(Work Log)",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                },
+                {
+                    content: "Work Log Analytic Account field is shown on the tab",
+                    trigger: ".o_field_widget[name='work_log_analytic_account_id']",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Modified Flow — the Fulfillment Work Logs tab is
+                // specific to Acceptance.
+                {
+                    content: "Fullfilment Work Logs tab is displayed",
+                    trigger: ".o_notebook .nav-link:contains(Fullfilment Work Logs)",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                },
+                {
+                    content: "Work Qty field is shown on the tab",
+                    trigger: ".o_field_widget[name='qty_work_log']",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // The work log list offered here is restricted to
+                // `allowed_work_log_ids`: only the fixture booked
+                // against the linked PoB's analytic account, dated
+                // within Date Start/Date End, and Done is selectable.
+                {
+                    content: "Open the Add dialog on the Work Logs list",
+                    trigger:
+                        ".o_field_widget[name='poa_work_log_ids'] .o_field_x2many_list_row_add a",
+                },
+                {
+                    content: "The allowed work log is offered in the dialog",
+                    trigger:
+                        ".modal .o_list_view .o_data_row:contains(TOUR-POBAWL-WORKLOG-1)",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    content: "Select the allowed work log's row",
+                    trigger:
+                        ".modal .o_list_view .o_data_row:contains(TOUR-POBAWL-WORKLOG-1) .o_list_record_selector input",
+                },
+                {
+                    content: "Confirm the selection",
+                    trigger: ".modal-footer .o_select_button",
+                    in_modal: true,
+                },
+
+                // Post-Condition of this delta — the picked work log now
+                // appears in the tab's own list. The tour stops here: it
+                // does not assert the resulting Work Qty value (unit
+                // test territory), and does not continue to Save.
+                {
+                    content: "The picked work log now appears on the tab",
+                    trigger:
+                        ".o_field_widget[name='poa_work_log_ids'] .o_data_row:contains(TOUR-POBAWL-WORKLOG-1)",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_tour.js
@@ -1,0 +1,96 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_revenue_recognition_work_log.performance_obligation_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/performance_obligation/01-create.md (delta of
+    // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
+    // the menu, open a new form, open the added Work Log tab, and
+    // assert its fields are rendered — then stop. It does not continue
+    // to Save/Confirm/Approve, which are already covered by the base
+    // module's own create tour, and it does not assert any computed
+    // value (Total/Remaining/Excess), which is unit test territory.
+    tour.register(
+        "ssi_revenue_recognition_work_log_performance_obligation_create",
+        {test: true, url: "/web"},
+        [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Revenue Recognition menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+            },
+            {
+                content: "Open the Performance Obligations menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_menu"]',
+            },
+            {
+                content: "Performance Obligations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Performance Obligations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Modified Flow — the Work Log tab is added by this
+            // module, present from the moment the form opens.
+            {
+                content: "Work Log tab is displayed",
+                trigger: ".o_notebook .nav-link:contains(Work Log)",
+                extra_trigger: ".o_form_view.o_form_editable",
+            },
+            {
+                content: "Work Log Analytic Account field is shown on the tab",
+                trigger: ".o_field_widget[name='work_log_analytic_account_id']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Estimation field is shown on the tab",
+                trigger: ".o_field_widget[name='work_estimation']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Work Logs list is shown on the tab",
+                trigger: ".o_field_widget[name='work_log_ids']",
+                run: function () {
+                    // Assertion only. The tour stops here — the list
+                    // stays empty in this delta (picking/creating a
+                    // work log line is out of scope for this
+                    // module's Design Decision), and Save/Confirm/
+                    // Approve are covered by the base create tour.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_revenue_recognition_work_log/static/tests/tours/revenue_recognition_tour.js
+++ b/ssi_revenue_recognition_work_log/static/tests/tours/revenue_recognition_tour.js
@@ -1,0 +1,96 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_revenue_recognition_work_log.revenue_recognition_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/revenue_recognition/01-create.md (delta of
+    // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
+    // the menu, open a new form, open the added Work Log tab, and
+    // assert its fields are rendered — then stop. It does not continue
+    // to Save/Confirm/Approve, which are already covered by the base
+    // module's own create tour, and it does not assert any computed
+    // value (Total/Remaining/Excess), which is unit test territory.
+    tour.register(
+        "ssi_revenue_recognition_work_log_revenue_recognition_create",
+        {test: true, url: "/web"},
+        [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Revenue Recognition menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+            },
+            {
+                content: "Open the Revenue Recognitions menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.revenue_recognition_menu"]',
+            },
+            {
+                content: "Revenue Recognitions list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Revenue Recognitions)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Modified Flow — the Work Log tab is added by this
+            // module, present from the moment the form opens.
+            {
+                content: "Work Log tab is displayed",
+                trigger: ".o_notebook .nav-link:contains(Work Log)",
+                extra_trigger: ".o_form_view.o_form_editable",
+            },
+            {
+                content: "Work Log Analytic Account field is shown on the tab",
+                trigger: ".o_field_widget[name='work_log_analytic_account_id']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Estimation field is shown on the tab",
+                trigger: ".o_field_widget[name='work_estimation']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Work Logs list is shown on the tab",
+                trigger: ".o_field_widget[name='work_log_ids']",
+                run: function () {
+                    // Assertion only. The tour stops here — the list
+                    // stays empty in this delta (picking/creating a
+                    // work log line is out of scope for this
+                    // module's Design Decision), and Save/Confirm/
+                    // Approve are covered by the base create tour.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_revenue_recognition_work_log/tests/__init__.py
+++ b/ssi_revenue_recognition_work_log/tests/__init__.py
@@ -2,4 +2,9 @@
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0-standalone.html).
 
-from . import test_performance_obligation_acceptance
+from . import (
+    test_performance_obligation_acceptance,
+    test_ui_performance_obligation,
+    test_ui_performance_obligation_acceptance,
+    test_ui_revenue_recognition,
+)

--- a/ssi_revenue_recognition_work_log/tests/test_ui_performance_obligation.py
+++ b/ssi_revenue_recognition_work_log/tests/test_ui_performance_obligation.py
@@ -1,0 +1,38 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPerformanceObligation(HttpSavepointCase):
+    """Tour test for the ``performance_obligation`` IK extension.
+
+    Covers the delta of ``docs/performance_obligation/01-create.md``
+    added by this module: the ``mixin.work_object`` **Work Log** tab.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant admin the group needed to create a Performance
+        Obligation.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: create needs `*_user_group`.
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_user_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+    def test_create(self):
+        """Run the delta create tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_work_log_performance_obligation_create",
+            login="admin",
+        )

--- a/ssi_revenue_recognition_work_log/tests/test_ui_performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition_work_log/tests/test_ui_performance_obligation_acceptance.py
@@ -1,0 +1,86 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPerformanceObligationAcceptance(HttpSavepointCase):
+    """Tour test for the ``performance_obligation_acceptance`` IK
+    extension.
+
+    Covers the delta of
+    ``docs/performance_obligation_acceptance/01-create.md`` added by
+    this module: the shared **Work Log** tab and the acceptance-only
+    **Fullfilment Work Logs** tab (``allowed_work_log_ids`` /
+    ``poa_work_log_ids`` / ``qty_work_log``).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create the PoB and a Done work log the tour can pick."""
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: create needs `*_user_group`.
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_acceptance_user_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+        cls.partner = cls.env["res.partner"].create({"name": "TOUR-POBAWL-PARTNER"})
+        source_aa = cls.env["account.analytic.account"].create(
+            {"name": "TOUR-POBAWL-SOURCE-AA", "partner_id": cls.partner.id}
+        )
+        pob_aa = cls.env["account.analytic.account"].create(
+            {"name": "TOUR-POBAWL-POB-AA", "partner_id": cls.partner.id}
+        )
+        # Background data: an already-Open PoB, on its own analytic
+        # account, the tour picks from the `# Performance Obligation`
+        # dropdown. Its own workflow is not under test here, so the
+        # state and analytic account are set directly instead of
+        # running the full approval chain (same approach as the YAML
+        # scenarios in test_data_performance_obligation_acceptance.yaml).
+        cls.pob = cls.env["performance_obligation"].create(
+            {
+                "title": "TOUR-POBAWL-POB",
+                "source_analytic_account_id": source_aa.id,
+                "analytic_account_id": pob_aa.id,
+                "user_id": cls.admin.id,
+                "name": "PB-TOUR-POBAWL-1",
+            }
+        )
+        cls.pob.write({"state": "open"})
+
+        # Background data: one Done work log booked against the PoB's
+        # analytic account, dated inside the window the tour will type
+        # into Date Start/Date End (2026-01-01..2026-01-31), so
+        # `allowed_work_log_ids` has exactly this one candidate to
+        # offer when the tour opens the Fullfilment Work Logs tab.
+        employee = cls.env["hr.employee"].create({"name": "TOUR-POBAWL-EMPLOYEE"})
+        ir_model = cls.env["ir.model"].search([("model", "=", "res.partner")], limit=1)
+        work_log = cls.env["hr.work_log"].create(
+            {
+                "employee_id": employee.id,
+                "description": "TOUR-POBAWL-WORKLOG-1",
+                "model_id": ir_model.id,
+                "work_object_id": cls.partner.id,
+                "date": "2026-01-15",
+                "amount": 4.0,
+                "analytic_account_id": pob_aa.id,
+            }
+        )
+        work_log.with_context(bypass_policy_check=True).action_confirm()
+        work_log.with_context(bypass_policy_check=True).action_approve_approval()
+
+    def test_create(self):
+        """Run the delta create tour for
+        ``performance_obligation_acceptance``.
+
+        IK: docs/performance_obligation_acceptance/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_work_log_performance_obligation_acceptance_create",
+            login="admin",
+        )

--- a/ssi_revenue_recognition_work_log/tests/test_ui_performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition_work_log/tests/test_ui_performance_obligation_acceptance.py
@@ -20,7 +20,9 @@ class TestUiPerformanceObligationAcceptance(HttpSavepointCase):
 
     @classmethod
     def setUpClass(cls):
-        """Create the PoB and a Done work log the tour can pick."""
+        """Create the PoB, an Open timesheet, and a Done work log the
+        tour can pick.
+        """
         super().setUpClass()
         cls.admin = cls.env.ref("base.user_admin")
         # Pre-Condition: create needs `*_user_group`.
@@ -52,12 +54,29 @@ class TestUiPerformanceObligationAcceptance(HttpSavepointCase):
         )
         cls.pob.write({"state": "open"})
 
+        # Background data: an Open `hr.timesheet` covering the work log's
+        # date, so the work log passes `_check_sheet_id`
+        # (`ssi_work_log_mixin`'s `_compute_sheet_id` only finds a sheet
+        # when one exists for the same employee with a date range that
+        # covers the log's date and status Open) — same prerequisite the
+        # YAML scenarios in
+        # test_data_performance_obligation_acceptance.yaml set up before
+        # creating a work log.
+        employee = cls.env["hr.employee"].create({"name": "TOUR-POBAWL-EMPLOYEE"})
+        timesheet = cls.env["hr.timesheet"].create(
+            {
+                "employee_id": employee.id,
+                "date_start": "2026-01-01",
+                "date_end": "2026-01-31",
+            }
+        )
+        timesheet.action_open()
+
         # Background data: one Done work log booked against the PoB's
         # analytic account, dated inside the window the tour will type
         # into Date Start/Date End (2026-01-01..2026-01-31), so
         # `allowed_work_log_ids` has exactly this one candidate to
         # offer when the tour opens the Fullfilment Work Logs tab.
-        employee = cls.env["hr.employee"].create({"name": "TOUR-POBAWL-EMPLOYEE"})
         ir_model = cls.env["ir.model"].search([("model", "=", "res.partner")], limit=1)
         work_log = cls.env["hr.work_log"].create(
             {

--- a/ssi_revenue_recognition_work_log/tests/test_ui_revenue_recognition.py
+++ b/ssi_revenue_recognition_work_log/tests/test_ui_revenue_recognition.py
@@ -1,0 +1,38 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiRevenueRecognition(HttpSavepointCase):
+    """Tour test for the ``revenue_recognition`` IK extension.
+
+    Covers the delta of ``docs/revenue_recognition/01-create.md`` added
+    by this module: the ``mixin.work_object`` **Work Log** tab.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant admin the group needed to create a Revenue
+        Recognition.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: create needs `*_user_group`.
+        cls.env.ref(
+            "ssi_revenue_recognition.revenue_recognition_user_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+    def test_create(self):
+        """Run the delta create tour for ``revenue_recognition``.
+
+        IK: docs/revenue_recognition/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_work_log_revenue_recognition_create",
+            login="admin",
+        )

--- a/ssi_revenue_recognition_work_log/views/assets.xml
+++ b/ssi_revenue_recognition_work_log/views/assets.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_revenue_recognition_work_log assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition_work_log/static/tests/tours/performance_obligation_acceptance_tour.js"
+            />
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition_work_log/static/tests/tours/revenue_recognition_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Summary
- Add `docs/` directory with IK extensions for the three inherited models bridged to `hr.work_log` (`performance_obligation`, `performance_obligation_acceptance`, `revenue_recognition`), each linking back to the base IK in `ssi_revenue_recognition`.
- Add one paired UI tour per IK extension (delta-only, does not assert computed values) plus `web.assets_tests` asset registration.
- Closes the `audit-sweep.sh` `ik` validator finding: module had no `docs/` directory.

## Test plan
- [x] `assets/validate-ik.sh` on the module: `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- [x] `assets/validate-tour.sh` on the module: `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- [x] `assets/verify-module.sh` on the module: `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- [x] `pre-commit-gate.sh`: `GATE OK: 6 pemeriksaan, 0 pelanggaran baru`
- [ ] CI (unit test + tour) — pending

Closes open-synergy/ssi-revenue-recognition#55