### PR TITLE
[UPD] ssi_performance_obligation_quality_control

### DIFF
--- a/ssi_performance_obligation_quality_control/README.rst
+++ b/ssi_performance_obligation_quality_control/README.rst
@@ -19,6 +19,11 @@ To install this module, you need to:
 5.  Search For *Performance Obligation + Quality Control Integration*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Performance Obligation <docs/performance_obligation/index.html>`_
+
 Bug Tracker
 ===========
 

--- a/ssi_performance_obligation_quality_control/__manifest__.py
+++ b/ssi_performance_obligation_quality_control/__manifest__.py
@@ -11,8 +11,11 @@
     "depends": [
         "ssi_revenue_recognition",
         "ssi_quality_control",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "demo": [],
     "images": [],
 }

--- a/ssi_performance_obligation_quality_control/docs/performance_obligation/01-create.md
+++ b/ssi_performance_obligation_quality_control/docs/performance_obligation/01-create.md
@@ -1,0 +1,26 @@
+# Create Performance Obligation
+
+> **Module:** ssi_performance_obligation_quality_control
+>
+> **Extends:** ssi_revenue_recognition — model `performance_obligation`, action
+> `01-create`
+
+## Modified Flow
+
+- Anchor: visible on the form from the moment it opens (before step 3 of the base Flow),
+  and present in every status afterward — because this module sets
+  `_qc_worksheet_create_page = True`, a **Quality Control** tab is added by
+  `mixin.qc_worksheet` (`ssi_quality_control`). It can be filled in **any status**; the
+  mixin does not restrict it to Draft. It holds:
+  - **Worksheet Set**: an editable field to pick the `qc_worksheet_set_id` template used
+    to auto-generate worksheets for this PoB via the **Create Worksheet From Set**
+    button. Optional, no default.
+  - **Result Computation Method**: an editable **Automatic**/**Manual** selection.
+    Defaults to **Automatic**.
+  - Read-only **Automatic** and **Final** result indicators, and an editable **Manual**
+    result checkbox (only meaningful when **Result Computation Method** is **Manual**).
+  - **Create Worksheet From Set** and **Open QC Worksheet** buttons, plus an embedded
+    **QC Worksheets** list.
+  - Creating, answering, and completing the worksheets themselves — including what the
+    two buttons above do — is governed by the `ssi_quality_control` module; this
+    extension does not repeat those steps.

--- a/ssi_performance_obligation_quality_control/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_performance_obligation_quality_control/static/tests/tours/performance_obligation_tour.js
@@ -1,100 +1,101 @@
 /* Copyright 2026 OpenSynergy Indonesia
  * Copyright 2026 PT. Simetri Sinergi Indonesia
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
-odoo.define("ssi_performance_obligation_quality_control.performance_obligation_tour", function (
-    require
-) {
-    "use strict";
+odoo.define(
+    "ssi_performance_obligation_quality_control.performance_obligation_tour",
+    function (require) {
+        "use strict";
 
-    var tour = require("web_tour.tour");
+        var tour = require("web_tour.tour");
 
-    // IK: docs/performance_obligation/01-create.md (delta of
-    // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
-    // the menu, open a new form, open the added Quality Control tab, and
-    // assert its fields are rendered — then stop. It does not continue
-    // to Save/Confirm/Approve, which are already covered by the base
-    // module's own create tour, and it does not assert any computed
-    // value (Automatic/Final result), which is unit test territory. It
-    // also does not click the Create Worksheet From Set / Open QC
-    // Worksheet buttons — operating the worksheet itself is governed by
-    // ssi_quality_control, out of scope for this module's Design
-    // Decision.
-    tour.register(
-        "ssi_performance_obligation_quality_control_performance_obligation_create",
-        {test: true, url: "/web"},
-        [
-            tour.stepUtils.showAppsMenuItem(),
-            {
-                content: "Open the Cost Accounting app",
-                trigger:
-                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
-            },
-            {
-                content: "Open the Revenue Recognition menu",
-                trigger:
-                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
-            },
-            {
-                content: "Open the Performance Obligations menu",
-                trigger:
-                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_menu"]',
-            },
-            {
-                content: "Performance Obligations list is displayed",
-                trigger:
-                    ".o_control_panel .breadcrumb-item.active:contains(Performance Obligations)",
-                extra_trigger: ".o_list_view",
-                run: function () {
-                    // Assertion only.
+        // IK: docs/performance_obligation/01-create.md (delta of
+        // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
+        // the menu, open a new form, open the added Quality Control tab, and
+        // assert its fields are rendered — then stop. It does not continue
+        // to Save/Confirm/Approve, which are already covered by the base
+        // module's own create tour, and it does not assert any computed
+        // value (Automatic/Final result), which is unit test territory. It
+        // also does not click the Create Worksheet From Set / Open QC
+        // Worksheet buttons — operating the worksheet itself is governed by
+        // ssi_quality_control, out of scope for this module's Design
+        // Decision.
+        tour.register(
+            "ssi_performance_obligation_quality_control_performance_obligation_create",
+            {test: true, url: "/web"},
+            [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Cost Accounting app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
                 },
-            },
+                {
+                    content: "Open the Revenue Recognition menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+                },
+                {
+                    content: "Open the Performance Obligations menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_menu"]',
+                },
+                {
+                    content: "Performance Obligations list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Performance Obligations)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
 
-            // Click the New button.
-            {
-                content: "Click Create",
-                trigger: ".o_list_button_add",
-                extra_trigger: ".o_list_view",
-            },
-            {
-                content: "Form is open in edit mode",
-                trigger: ".o_form_view.o_form_editable",
-                run: function () {
-                    // Assertion only.
+                // Click the New button.
+                {
+                    content: "Click Create",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
                 },
-            },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
 
-            // Modified Flow — the Quality Control tab is added by this
-            // module, present from the moment the form opens.
-            {
-                content: "Quality Control tab is displayed",
-                trigger: ".o_notebook .nav-link:contains(Quality Control)",
-                extra_trigger: ".o_form_view.o_form_editable",
-            },
-            {
-                content: "Worksheet Set field is shown on the tab",
-                trigger: ".o_field_widget[name='qc_worksheet_set_id']",
-                run: function () {
-                    // Assertion only.
+                // Modified Flow — the Quality Control tab is added by this
+                // module, present from the moment the form opens.
+                {
+                    content: "Quality Control tab is displayed",
+                    trigger: ".o_notebook .nav-link:contains(Quality Control)",
+                    extra_trigger: ".o_form_view.o_form_editable",
                 },
-            },
-            {
-                content: "Result Computation Method field is shown on the tab",
-                trigger: ".o_field_widget[name='qc_result_computation_method']",
-                run: function () {
-                    // Assertion only.
+                {
+                    content: "Worksheet Set field is shown on the tab",
+                    trigger: ".o_field_widget[name='qc_worksheet_set_id']",
+                    run: function () {
+                        // Assertion only.
+                    },
                 },
-            },
-            {
-                content: "QC Worksheets list is shown on the tab",
-                trigger: ".o_field_widget[name='qc_worksheet_ids']",
-                run: function () {
-                    // Assertion only. The tour stops here — it does not
-                    // click Create Worksheet From Set / Open QC
-                    // Worksheet (governed by ssi_quality_control), and
-                    // Save/Confirm/Approve are covered by the base
-                    // create tour.
+                {
+                    content: "Result Computation Method field is shown on the tab",
+                    trigger: ".o_field_widget[name='qc_result_computation_method']",
+                    run: function () {
+                        // Assertion only.
+                    },
                 },
-            },
-        ]
-    );
-});
+                {
+                    content: "QC Worksheets list is shown on the tab",
+                    trigger: ".o_field_widget[name='qc_worksheet_ids']",
+                    run: function () {
+                        // Assertion only. The tour stops here — it does not
+                        // click Create Worksheet From Set / Open QC
+                        // Worksheet (governed by ssi_quality_control), and
+                        // Save/Confirm/Approve are covered by the base
+                        // create tour.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_performance_obligation_quality_control/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_performance_obligation_quality_control/static/tests/tours/performance_obligation_tour.js
@@ -1,0 +1,100 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define("ssi_performance_obligation_quality_control.performance_obligation_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // IK: docs/performance_obligation/01-create.md (delta of
+    // ssi_revenue_recognition's own 01-create.md). Delta-only tour: open
+    // the menu, open a new form, open the added Quality Control tab, and
+    // assert its fields are rendered — then stop. It does not continue
+    // to Save/Confirm/Approve, which are already covered by the base
+    // module's own create tour, and it does not assert any computed
+    // value (Automatic/Final result), which is unit test territory. It
+    // also does not click the Create Worksheet From Set / Open QC
+    // Worksheet buttons — operating the worksheet itself is governed by
+    // ssi_quality_control, out of scope for this module's Design
+    // Decision.
+    tour.register(
+        "ssi_performance_obligation_quality_control_performance_obligation_create",
+        {test: true, url: "/web"},
+        [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the Cost Accounting app",
+                trigger:
+                    '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+            },
+            {
+                content: "Open the Revenue Recognition menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+            },
+            {
+                content: "Open the Performance Obligations menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_menu"]',
+            },
+            {
+                content: "Performance Obligations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Performance Obligations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Click the New button.
+            {
+                content: "Click Create",
+                trigger: ".o_list_button_add",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open in edit mode",
+                trigger: ".o_form_view.o_form_editable",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+
+            // Modified Flow — the Quality Control tab is added by this
+            // module, present from the moment the form opens.
+            {
+                content: "Quality Control tab is displayed",
+                trigger: ".o_notebook .nav-link:contains(Quality Control)",
+                extra_trigger: ".o_form_view.o_form_editable",
+            },
+            {
+                content: "Worksheet Set field is shown on the tab",
+                trigger: ".o_field_widget[name='qc_worksheet_set_id']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Result Computation Method field is shown on the tab",
+                trigger: ".o_field_widget[name='qc_result_computation_method']",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "QC Worksheets list is shown on the tab",
+                trigger: ".o_field_widget[name='qc_worksheet_ids']",
+                run: function () {
+                    // Assertion only. The tour stops here — it does not
+                    // click Create Worksheet From Set / Open QC
+                    // Worksheet (governed by ssi_quality_control), and
+                    // Save/Confirm/Approve are covered by the base
+                    // create tour.
+                },
+            },
+        ]
+    );
+});

--- a/ssi_performance_obligation_quality_control/tests/__init__.py
+++ b/ssi_performance_obligation_quality_control/tests/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import (
+    test_ui_performance_obligation,
+)

--- a/ssi_performance_obligation_quality_control/tests/test_ui_performance_obligation.py
+++ b/ssi_performance_obligation_quality_control/tests/test_ui_performance_obligation.py
@@ -1,0 +1,39 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase — BUKAN HttpCase, lihat structure-and-runner.md §Base class.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPerformanceObligation(HttpSavepointCase):
+    """Tour test for the ``performance_obligation`` IK extension.
+
+    Covers the delta of ``docs/performance_obligation/01-create.md``
+    added by this module: the ``mixin.qc_worksheet`` **Quality
+    Control** tab.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Grant admin the group needed to create a Performance
+        Obligation.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        # Pre-Condition: create needs `*_user_group`.
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_user_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+
+    def test_create(self):
+        """Run the delta create tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_performance_obligation_quality_control_performance_obligation_create",
+            login="admin",
+        )

--- a/ssi_performance_obligation_quality_control/views/assets.xml
+++ b/ssi_performance_obligation_quality_control/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_performance_obligation_quality_control assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_performance_obligation_quality_control/static/tests/tours/performance_obligation_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan direktori `docs/` berisi IK extension untuk `performance_obligation` yang
mendokumentasikan tab **Quality Control** tambahan (`mixin.qc_worksheet`,
`_qc_worksheet_create_page = True`) pada form Performance Obligation: kapan tampil, state
yang dapat diisi, dan bahwa isian worksheet-nya diatur modul `ssi_quality_control` (tidak
disalin ulang di sini). Tour pasangan IK ditambahkan (buka form, buka tab Quality
Control, verifikasi field ter-render, berhenti tanpa mengklik tombol worksheet) beserta
pendaftaran aset dan berkas `HttpCase` pemanggil.

Menutup temuan sapuan `audit-sweep.sh 14.0 --repo ssi-revenue-recognition` (validator
`ik`): `modul-tak-punya-direktori-docs-belum-ada-ik-sama-sekali|docs/`.

## Verifikasi

- `validate-ik.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `validate-tour.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `verify-module.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `pre-commit-gate.sh` → `GATE OK: 6 pemeriksaan, 0 pelanggaran baru`

Closes #56