### PR TITLE
[UPD] ssi_performance_obligation_quality_control

### DIFF
--- a/ssi_performance_obligation_quality_control/tests/__init__.py
+++ b/ssi_performance_obligation_quality_control/tests/__init__.py
@@ -3,5 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import (
+    test_performance_obligation,
     test_ui_performance_obligation,
 )

--- a/ssi_performance_obligation_quality_control/tests/test_data_performance_obligation.yaml
+++ b/ssi_performance_obligation_quality_control/tests/test_data_performance_obligation.yaml
@@ -1,0 +1,117 @@
+scenarios:
+  - name: "QC worksheet surface is present but empty on a new PoB"
+    steps:
+      - step: "Create source analytic account of the contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_1"
+        values:
+          name: "Test Source AA - QC Surface 1"
+
+      - step: "Create draft PoB pointing at the source analytic account"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_1"
+        values:
+          title: "Test PoB - QC Surface 1"
+          source_analytic_account_id: "REC: source_aa_1.id"
+
+      - step: "qc_worksheet_ids contributed by the mixin is empty"
+        action: "assert"
+        target: "pob_1"
+        asserts:
+          qc_worksheet_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+      - step: "qc_worksheet_set_id contributed by the mixin is unset"
+        action: "assert"
+        target: "pob_1"
+        asserts:
+          qc_worksheet_set_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Approval flow reaches open with the QC mixin installed"
+    steps:
+      - step: "Create source analytic account of the contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_2"
+        values:
+          name: "Test Source AA - QC Open Flow 2"
+
+      - step: "Create draft PoB as admin (owns the record for as_user steps)"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_2"
+        as_user: "base.user_admin"
+        values:
+          title: "Test PoB - QC Open Flow 2"
+          source_analytic_account_id: "REC: source_aa_2.id"
+
+      - step: "Confirm the PoB"
+        action: "call"
+        target: "pob_2"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04) -- tanpa
+      # step ini approve_ok bisa terbaca dari cache yang diisi
+      # action_confirm, saat approval.approval belum ada.
+      - step: "PoB is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "pob_2"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the PoB (auto-runs action_open via _after_approved_method)"
+        action: "call"
+        target: "pob_2"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+  - name: "action_open is still rejected on a draft PoB with the QC mixin installed"
+    steps:
+      - step: "Create source analytic account of the contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_3"
+        values:
+          name: "Test Source AA - QC Open Guard 3"
+
+      - step: "Create draft PoB pointing at the source analytic account"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_3"
+        values:
+          title: "Test PoB - QC Open Guard 3"
+          source_analytic_account_id: "REC: source_aa_3.id"
+
+      - step: "action_open on a draft PoB is rejected"
+        action: "call"
+        target: "pob_3"
+        method: "action_open"
+        expect_error:
+          type: "UserError"
+          message_contains: "Document cannot be opened from its current state"
+
+      - step: "State stays draft"
+        action: "assert"
+        target: "pob_3"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"

--- a/ssi_performance_obligation_quality_control/tests/test_performance_obligation.py
+++ b/ssi_performance_obligation_quality_control/tests/test_performance_obligation.py
@@ -1,0 +1,23 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPerformanceObligation(YamlTransactionCase):
+    """Scenario tests for ``mixin.qc_worksheet`` on ``performance_obligation``.
+
+    Covers issue #63: the QC worksheet surface the mixin contributes
+    (``qc_worksheet_ids``, ``qc_worksheet_set_id``) must be readable
+    and empty on a freshly created PoB, the ``draft -> open`` approval
+    flow must keep working with the mixin installed, and the existing
+    ``action_open`` source-state guard must still reject a draft PoB.
+    """
+
+    def test_performance_obligation(self):
+        """Run the QC worksheet surface and open-guard scenarios."""
+        self.run_yaml_scenario("test_data_performance_obligation.yaml")


### PR DESCRIPTION
## Ringkasan

Menambahkan direktori `tests/` berisi skenario `odoo-yaml-test` untuk modul
`ssi_performance_obligation_quality_control` yang mengunci terpasangnya
permukaan QC worksheet (`qc_worksheet_ids`, `qc_worksheet_set_id`) yang
disumbang `mixin.qc_worksheet` ke `performance_obligation`.

- Positif: PoB baru → field/relasi worksheet QC dapat dibaca dan kosong.
- Positif: alur `draft` → `confirm` → `open` lewat action method sungguhan
  dengan mixin QC terpasang, membuktikan mixin tidak menghalangi transisi
  state yang sudah ada.
- Negatif: `action_open` pada dokumen `draft` tetap ditolak `UserError`
  seperti sebelum mixin dipasang.

Tidak ada perubahan pada `models/`, `views/`, atau `security/`.

Closes #63