### PR TITLE
[UPD] ssi_revenue_recognition_operating_unit: unit test perambatan Operating Unit

### DIFF
--- a/ssi_revenue_recognition_operating_unit/tests/__init__.py
+++ b/ssi_revenue_recognition_operating_unit/tests/__init__.py
@@ -2,6 +2,9 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import test_performance_obligation
+from . import test_performance_obligation_acceptance
+from . import test_revenue_recognition
 from . import test_ui_performance_obligation
 from . import test_ui_performance_obligation_acceptance
 from . import test_ui_revenue_recognition

--- a/ssi_revenue_recognition_operating_unit/tests/test_data_performance_obligation.yaml
+++ b/ssi_revenue_recognition_operating_unit/tests/test_data_performance_obligation.yaml
@@ -1,0 +1,102 @@
+options:
+  auto_refresh: true
+
+setup:
+  steps:
+    - step: "Create the shared partner for both operating units"
+      action: "create"
+      model: "res.partner"
+      save_as: "ou_partner"
+      values:
+        name: "EVAL: 'Test PoB OU Partner %d' % env['res.partner'].search_count([])"
+        is_company: true
+
+    - step: "Create the first operating unit (not used on the PoB under test)"
+      action: "create"
+      model: "operating.unit"
+      save_as: "ou_1"
+      values:
+        name: "EVAL: 'Test PoB OU 1 %d' % env['operating.unit'].search_count([])"
+        code: "EVAL: 'POBOU1%d' % env['operating.unit'].search_count([])"
+        partner_id: "REC: ou_partner.id"
+
+    - step: "Create the second operating unit (assigned to the PoB under test)"
+      action: "create"
+      model: "operating.unit"
+      save_as: "ou_2"
+      values:
+        name: "EVAL: 'Test PoB OU 2 %d' % env['operating.unit'].search_count([])"
+        code: "EVAL: 'POBOU2%d' % env['operating.unit'].search_count([])"
+        partner_id: "REC: ou_partner.id"
+
+    - step: "Create the source analytic account of the contract"
+      action: "create"
+      model: "account.analytic.account"
+      save_as: "source_aa"
+      values:
+        name:
+          "EVAL: 'Test PoB OU Source AA %d' %
+          env['account.analytic.account'].search_count([])"
+
+scenarios:
+  - name: "Creating a PoB with a non-default operating unit stores it"
+    steps:
+      - step: "Create draft PoB directly on the second operating unit"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob"
+        values:
+          title: "Test PoB - Operating Unit 2"
+          source_analytic_account_id: "REC: source_aa.id"
+          operating_unit_id: "REC: ou_2.id"
+
+      - step: "operating_unit_id is the second operating unit, not falsy/default"
+        action: "assert"
+        target: "pob"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: ou_2"
+
+  - name:
+      "A user without rights over the second operating unit cannot read a PoB owned by
+      it"
+    steps:
+      - step: "Create draft PoB on the second operating unit as superuser"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob"
+        values:
+          title: "Test PoB - OU AccessError"
+          source_analytic_account_id: "REC: source_aa.id"
+          operating_unit_id: "REC: ou_2.id"
+
+      - step:
+          "Create an internal user in the OU group, assigned only the first operating
+          unit"
+        action: "create"
+        model: "res.users"
+        save_as: "restricted_user"
+        values:
+          name: "Test PoB OU Restricted User"
+          login: "EVAL: 'test_pob_ou_restricted_%d' % env['res.users'].search_count([])"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF:
+                  ssi_revenue_recognition_operating_unit.service_contract_performance_obligation_ou_group"
+          assigned_operating_unit_ids:
+            - - 6
+              - 0
+              - - "REC: ou_1.id"
+
+      - step: "Reading the PoB as that user raises AccessError"
+        action: "call"
+        target: "pob"
+        method: "read"
+        args:
+          - - "id"
+        as_user: "restricted_user"
+        expect_error:
+          type: "AccessError"

--- a/ssi_revenue_recognition_operating_unit/tests/test_data_performance_obligation_acceptance.yaml
+++ b/ssi_revenue_recognition_operating_unit/tests/test_data_performance_obligation_acceptance.yaml
@@ -1,0 +1,79 @@
+options:
+  auto_refresh: true
+
+setup:
+  steps:
+    - step: "Create the shared partner for both operating units"
+      action: "create"
+      model: "res.partner"
+      save_as: "ou_partner"
+      values:
+        name: "EVAL: 'Test PoA OU Partner %d' % env['res.partner'].search_count([])"
+        is_company: true
+
+    - step: "Create the customer partner of the acceptance"
+      action: "create"
+      model: "res.partner"
+      save_as: "customer"
+      values:
+        name: "EVAL: 'Test PoA OU Customer %d' % env['res.partner'].search_count([])"
+
+    - step: "Create the first operating unit (not used on the PoB under test)"
+      action: "create"
+      model: "operating.unit"
+      save_as: "ou_1"
+      values:
+        name: "EVAL: 'Test PoA OU 1 %d' % env['operating.unit'].search_count([])"
+        code: "EVAL: 'POAOU1%d' % env['operating.unit'].search_count([])"
+        partner_id: "REC: ou_partner.id"
+
+    - step: "Create the second operating unit (assigned to the PoB under test)"
+      action: "create"
+      model: "operating.unit"
+      save_as: "ou_2"
+      values:
+        name: "EVAL: 'Test PoA OU 2 %d' % env['operating.unit'].search_count([])"
+        code: "EVAL: 'POAOU2%d' % env['operating.unit'].search_count([])"
+        partner_id: "REC: ou_partner.id"
+
+    - step: "Create the source analytic account of the contract"
+      action: "create"
+      model: "account.analytic.account"
+      save_as: "source_aa"
+      values:
+        name:
+          "EVAL: 'Test PoA OU Source AA %d' %
+          env['account.analytic.account'].search_count([])"
+
+    - step: "Create the Performance Obligation on the second operating unit"
+      action: "create"
+      model: "performance_obligation"
+      save_as: "pob"
+      values:
+        title: "Test PoB - PoA OU Parent"
+        source_analytic_account_id: "REC: source_aa.id"
+        operating_unit_id: "REC: ou_2.id"
+
+scenarios:
+  - name:
+      "An acceptance inherits its PoB's non-default operating unit, not the acting
+      user's default"
+    steps:
+      - step: "Create a draft acceptance for the PoB on the second operating unit"
+        action: "create"
+        model: "performance_obligation_acceptance"
+        save_as: "acceptance"
+        values:
+          partner_id: "REC: customer.id"
+          performance_obligation_id: "REC: pob.id"
+          date: 2024-01-31
+          date_start: 2024-01-01
+          date_end: 2024-01-31
+
+      - step: "operating_unit_id mirrors the PoB's second operating unit"
+        action: "assert"
+        target: "acceptance"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: ou_2"

--- a/ssi_revenue_recognition_operating_unit/tests/test_data_revenue_recognition.yaml
+++ b/ssi_revenue_recognition_operating_unit/tests/test_data_revenue_recognition.yaml
@@ -1,0 +1,147 @@
+options:
+  auto_refresh: true
+
+setup:
+  steps:
+    - step: "Create the shared partner for both operating units"
+      action: "create"
+      model: "res.partner"
+      save_as: "ou_partner"
+      values:
+        name: "EVAL: 'Test RR OU Partner %d' % env['res.partner'].search_count([])"
+        is_company: true
+
+    - step: "Create the customer partner of the recognition"
+      action: "create"
+      model: "res.partner"
+      save_as: "customer"
+      values:
+        name: "EVAL: 'Test RR OU Customer %d' % env['res.partner'].search_count([])"
+
+    - step: "Create the second operating unit (assigned to the PoB under test)"
+      action: "create"
+      model: "operating.unit"
+      save_as: "ou_2"
+      values:
+        name: "EVAL: 'Test RR OU 2 %d' % env['operating.unit'].search_count([])"
+        code: "EVAL: 'RROU2%d' % env['operating.unit'].search_count([])"
+        partner_id: "REC: ou_partner.id"
+
+    - step: "Create the source analytic account of the contract"
+      action: "create"
+      model: "account.analytic.account"
+      save_as: "source_aa"
+      values:
+        name:
+          "EVAL: 'Test RR OU Source AA %d' %
+          env['account.analytic.account'].search_count([])"
+
+    - step: "Create the Performance Obligation on the second operating unit"
+      action: "create"
+      model: "performance_obligation"
+      save_as: "pob"
+      values:
+        title: "Test PoB - RR OU Parent"
+        source_analytic_account_id: "REC: source_aa.id"
+        operating_unit_id: "REC: ou_2.id"
+
+    - step: "Create the type's journal"
+      action: "create"
+      model: "account.journal"
+      save_as: "type_journal"
+      values:
+        name:
+          "EVAL: 'Test RR OU Type Journal %d' % env['account.journal'].search_count([])"
+        code: "EVAL: 'RROUTJ%d' % env['account.journal'].search_count([])"
+        type: "general"
+
+    - step: "Create the unearned income usage"
+      action: "create"
+      model: "product.usage_type"
+      save_as: "usage_unearned"
+      values:
+        name:
+          "EVAL: 'Test RR OU Unearned Usage %d' %
+          env['product.usage_type'].search_count([])"
+        code: "EVAL: 'RROUUU%d' % env['product.usage_type'].search_count([])"
+
+    - step: "Create the income usage"
+      action: "create"
+      model: "product.usage_type"
+      save_as: "usage_income"
+      values:
+        name:
+          "EVAL: 'Test RR OU Income Usage %d' %
+          env['product.usage_type'].search_count([])"
+        code: "EVAL: 'RROUIU%d' % env['product.usage_type'].search_count([])"
+
+    - step: "Create the recognition type"
+      action: "create"
+      model: "revenue_recognition_type"
+      save_as: "rrt"
+      values:
+        name:
+          "EVAL: 'Test RR OU Type %d' % env['revenue_recognition_type'].search_count([])"
+        code: "EVAL: 'RROUT%d' % env['revenue_recognition_type'].search_count([])"
+        journal_id: "REC: type_journal.id"
+        unearned_income_usage_id: "REC: usage_unearned.id"
+        income_usage_id: "REC: usage_income.id"
+
+    - step: "Create the recognition journal"
+      action: "create"
+      model: "account.journal"
+      save_as: "journal"
+      values:
+        name: "EVAL: 'Test RR OU Journal %d' % env['account.journal'].search_count([])"
+        code: "EVAL: 'RROUJ%d' % env['account.journal'].search_count([])"
+        type: "general"
+
+    - step: "Create the unearned income account"
+      action: "create"
+      model: "account.account"
+      save_as: "unearned_account"
+      values:
+        name:
+          "EVAL: 'Test RR OU Unearned Account %d' %
+          env['account.account'].search_count([])"
+        code: "EVAL: 'RROUUA%d' % env['account.account'].search_count([])"
+        user_type_id: "REF: account.data_account_type_current_liabilities"
+
+    - step: "Create the income account"
+      action: "create"
+      model: "account.account"
+      save_as: "income_account"
+      values:
+        name:
+          "EVAL: 'Test RR OU Income Account %d' %
+          env['account.account'].search_count([])"
+        code: "EVAL: 'RROUIA%d' % env['account.account'].search_count([])"
+        user_type_id: "REF: account.data_account_type_revenue"
+
+scenarios:
+  - name:
+      "A revenue recognition inherits its PoB's non-default operating unit, not the
+      acting user's default"
+    steps:
+      - step: "Create a draft revenue recognition for the PoB on the 2nd OU"
+        action: "create"
+        model: "revenue_recognition"
+        save_as: "rr"
+        values:
+          type_id: "REC: rrt.id"
+          partner_id: "REC: customer.id"
+          performance_obligation_id: "REC: pob.id"
+          date: 2024-01-31
+          date_start: 2024-01-01
+          date_end: 2024-01-31
+          journal_id: "REC: journal.id"
+          unearned_income_account_id: "REC: unearned_account.id"
+          income_account_id: "REC: income_account.id"
+
+      - step: "operating_unit_id mirrors the PoB's second operating unit"
+        action: "assert"
+        target: "rr"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: ou_2"

--- a/ssi_revenue_recognition_operating_unit/tests/test_performance_obligation.py
+++ b/ssi_revenue_recognition_operating_unit/tests/test_performance_obligation.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPerformanceObligation(YamlTransactionCase):
+    """Scenario tests for ``performance_obligation`` operating unit.
+
+    Covers issue #59: ``operating_unit_id`` is stamped as a plain,
+    editable field on ``performance_obligation`` -- not derived from
+    the acting user's default operating unit -- and a user who is
+    only granted the second operating unit's sibling group but not
+    assigned to that operating unit is denied read access to a PoB
+    owned by it.
+    """
+
+    def test_performance_obligation(self):
+        """Run the PoB operating unit scenarios."""
+        self.run_yaml_scenario("test_data_performance_obligation.yaml")

--- a/ssi_revenue_recognition_operating_unit/tests/test_performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition_operating_unit/tests/test_performance_obligation_acceptance.py
@@ -1,0 +1,23 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPerformanceObligationAcceptance(YamlTransactionCase):
+    """Scenario tests for ``performance_obligation_acceptance`` OU.
+
+    Covers issue #59: ``operating_unit_id`` is a stored ``related``
+    field mirroring ``performance_obligation_id.operating_unit_id``,
+    so an acceptance always carries its performance obligation's
+    operating unit -- proven here with an operating unit that is not
+    the acting user's default one.
+    """
+
+    def test_performance_obligation_acceptance(self):
+        """Run the acceptance operating unit propagation scenario."""
+        self.run_yaml_scenario("test_data_performance_obligation_acceptance.yaml")

--- a/ssi_revenue_recognition_operating_unit/tests/test_revenue_recognition.py
+++ b/ssi_revenue_recognition_operating_unit/tests/test_revenue_recognition.py
@@ -1,0 +1,23 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestRevenueRecognition(YamlTransactionCase):
+    """Scenario tests for ``revenue_recognition`` operating unit.
+
+    Covers issue #59: ``operating_unit_id`` is a stored ``related``
+    field mirroring ``performance_obligation_id.operating_unit_id``,
+    so a revenue recognition always carries its performance
+    obligation's operating unit -- proven here with an operating unit
+    that is not the acting user's default one.
+    """
+
+    def test_revenue_recognition(self):
+        """Run the revenue recognition operating unit propagation scenario."""
+        self.run_yaml_scenario("test_data_revenue_recognition.yaml")


### PR DESCRIPTION
## Ringkasan

- Menambahkan direktori `tests/` (skenario `odoo-yaml-test`) yang mengunci
  pengisian `operating_unit_id` pada `performance_obligation` (field biasa)
  dan perambatannya ke `performance_obligation_acceptance` &
  `revenue_recognition` (related field), memakai Operating Unit kedua yang
  bukan default user.
- Menguji negatif: user yang hanya diberi grup Operating Unit tapi tidak
  ditugaskan ke OU kedua tidak bisa membaca `performance_obligation` ber-OU
  kedua (`AccessError`).
- Dua skenario dari issue sengaja **tidak** ditulis di sini karena kode
  produksinya belum mendukung (diverifikasi ke source, bukan diasumsikan):
  - Negatif "write `operating_unit_id` pada dokumen `done`" → sudah tercatat
    di #72 (masih terbuka).
  - Positif "`revenue_recognition` sampai `done` → `account.move` turunannya
    memikul OU yang sama" → `account.move` tidak punya field itu sama sekali
    di closure dependensi modul ini; dicatat sebagai issue baru #82.

## Test plan

- [x] `validate-unit-test.sh` → `LOLOS: 0 ERROR`
- [x] `pre-commit-gate.sh` → `GATE OK`
- [ ] CI GitHub hijau

Closes open-synergy/ssi-revenue-recognition#59