### PR TITLE
[UPD] ssi_revenue_recognition_project - Unit test skenario auto_create_project

### DIFF
--- a/ssi_revenue_recognition_project/tests/test_data_performance_obligation.yaml
+++ b/ssi_revenue_recognition_project/tests/test_data_performance_obligation.yaml
@@ -48,7 +48,7 @@ scenarios:
       # WAJIB: memaksa refresh sebelum approval dibaca (T-04) -- tanpa
       # step ini approve_ok bisa terbaca dari cache yang diisi
       # action_confirm, saat approval.approval belum ada.
-      - step: "PoB is confirm before approving"
+      - step: "PoB is confirm before approving, still without a project"
         action: "assert"
         refresh: true
         target: "pob_1"
@@ -56,6 +56,9 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
+          project_id:
+            type: "value"
+            operator: "is_falsy"
 
       - step: "Approve the PoB (auto-runs action_open, no ValueError)"
         action: "call"
@@ -91,6 +94,28 @@ scenarios:
           project_id.date:
             type: "value"
             expected: 2026-12-31
+
+      - step:
+          "Searching project.project by the PoB's own analytic account finds exactly the
+          linked project"
+        action: "search"
+        model: "project.project"
+        domain: [["analytic_account_id", "=", "REC: pob_aa_1.id"]]
+        save_as: "found_project_1"
+        expect_count: 1
+
+      - step:
+          "The found project is exactly the one linked to the PoB, named per
+          _prepare_project_data"
+        action: "assert"
+        target: "found_project_1"
+        asserts:
+          id:
+            type: "value"
+            expected: "REC: pob_1.project_id.id"
+          name:
+            type: "value"
+            expected: "Test PoB - Auto Create Project 1"
 
   - name: "Opening a PoB without auto_create_project creates no project"
     steps:
@@ -146,6 +171,54 @@ scenarios:
         action: "assert"
         target: "pob_2"
         asserts:
+          project_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Calling action_open directly on a draft PoB is rejected"
+    steps:
+      - step: "Create source analytic account with a partner"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_3"
+        values:
+          name: "Test Source AA - Auto Create Project 3"
+          partner_id: "REF: base.res_partner_2"
+
+      - step: "Create draft PoB with auto_create_project enabled"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_3"
+        as_user: "base.user_admin"
+        values:
+          title: "Test PoB - Auto Create Project 3"
+          source_analytic_account_id: "REC: source_aa_3.id"
+          auto_create_project: true
+
+      - step: "PoB is still draft before the rejected call"
+        action: "assert"
+        target: "pob_3"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+      - step: "Calling action_open directly from draft is rejected"
+        action: "call"
+        target: "pob_3"
+        method: "action_open"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "UserError"
+
+      - step: "PoB stays draft with no project created"
+        action: "assert"
+        refresh: true
+        target: "pob_3"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
           project_id:
             type: "value"
             operator: "is_falsy"

--- a/ssi_revenue_recognition_project/tests/test_performance_obligation.py
+++ b/ssi_revenue_recognition_project/tests/test_performance_obligation.py
@@ -14,7 +14,14 @@ class TestPerformanceObligation(YamlTransactionCase):
     Covers ``_01_create_project`` (``post_open_action`` hook): opening a
     PoB with ``auto_create_project`` enabled must create a
     ``project.project`` without sending the invalid ``code`` key, and
-    opening a PoB with it disabled must not create any project.
+    opening a PoB with it disabled must not create any project. Also
+    asserts ``project_id`` stays empty through ``draft`` and ``confirm``
+    (proving the project is born on the ``open`` transition, not
+    earlier), that ``project.project`` search-resolves to exactly the
+    linked record named per ``_prepare_project_data``, and that calling
+    ``action_open`` directly on a ``draft`` PoB is rejected with a
+    ``UserError`` (the ``_10_check_open_source_state`` guard from
+    ``ssi_revenue_recognition``) without creating a project.
     """
 
     def test_performance_obligation(self):


### PR DESCRIPTION
## Ringkasan

Melengkapi skenario `odoo-yaml-test` untuk hook `_01_create_project`
(`post_open_action`) pada `performance_obligation`, sesuai `## Skenario Uji`
issue #60:

* Assert `project_id` kosong pada state `confirm` (sebelumnya hanya dicek di
  `draft`), membuktikan project lahir tepat pada transisi ke `open`.
* Search `project.project` via domain untuk membuktikan tepat satu record
  ditemukan, dengan nama mengikuti nilai yang disusun `_prepare_project_data`.
* Skenario negatif: memanggil `action_open` langsung pada dokumen `draft`
  menghasilkan `UserError` dari guard `_10_check_open_source_state`
  (`ssi_revenue_recognition`, issue #74 -- sudah closed/completed), dengan
  `project_id` tetap kosong.
* Docstring class `TestPerformanceObligation` diperbarui menyebut cakupan
  skenario tambahan.

Struktur `tests/` modul ini sudah ada (dibuat oleh PR sebelumnya untuk
issue #78), jadi PR ini hanya memperluas isi skenario YAML-nya agar cocok
persis dengan `## Skenario Uji` issue #60. Tidak ada perubahan pada
`models/`, `views/`, atau `security/`.

## Verifikasi

```
#VALIDATOR name=unit-test target=.../ssi_revenue_recognition_project series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-revenue-recognition modules=1 failed=0 skipped=0 status=OK
```

Closes open-synergy/ssi-revenue-recognition#60