### PR TITLE
[UPD] ssi_revenue_recognition_project_operating_unit - IK extension glue project OU

### DIFF
--- a/ssi_revenue_recognition_project_operating_unit/README.rst
+++ b/ssi_revenue_recognition_project_operating_unit/README.rst
@@ -20,6 +20,11 @@ To install this module, you need to:
 5.  Search For *Revenue Recognition + Project + Operating Unit Integration*
 6.  Install the module
 
+Work Instruction
+================
+
+* `Approve Performance Obligation <docs/performance_obligation/05-approve.html>`_
+
 Credits
 =======
 

--- a/ssi_revenue_recognition_project_operating_unit/__manifest__.py
+++ b/ssi_revenue_recognition_project_operating_unit/__manifest__.py
@@ -13,8 +13,11 @@
         "ssi_revenue_recognition_project",
         "ssi_revenue_recognition_operating_unit",
         "ssi_project_operating_unit",
+        "web_tour",
     ],
-    "data": [],
+    "data": [
+        "views/assets.xml",
+    ],
     "images": [
         "static/description/banner.png",
     ],

--- a/ssi_revenue_recognition_project_operating_unit/docs/performance_obligation/05-approve.md
+++ b/ssi_revenue_recognition_project_operating_unit/docs/performance_obligation/05-approve.md
@@ -1,0 +1,16 @@
+# Approve Performance Obligation
+
+> **Module:** ssi_revenue_recognition_project_operating_unit
+>
+> **Extends:** ssi_revenue_recognition_project — model `performance_obligation`, aksi
+> `05-approve`
+
+## Additional Post-Condition
+
+- When the Approve action reaches **Open** and a `project.project` is created (or
+  refreshed) as documented by the extended module's own
+  `docs/performance_obligation/05-approve.md`, that project's **Operating Unit** follows
+  the PoB's own **Operating Unit** — not the acting user's default, not the project's
+  previous value. This is not a Flow step; it runs automatically as part of the same
+  Approve action, inside the project-creation side effect owned by
+  `ssi_revenue_recognition_project`.

--- a/ssi_revenue_recognition_project_operating_unit/static/tests/tours/performance_obligation_tour.js
+++ b/ssi_revenue_recognition_project_operating_unit/static/tests/tours/performance_obligation_tour.js
@@ -1,0 +1,102 @@
+/* Copyright 2026 OpenSynergy Indonesia
+ * Copyright 2026 PT. Simetri Sinergi Indonesia
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define(
+    "ssi_revenue_recognition_project_operating_unit.performance_obligation_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // IK: docs/performance_obligation/05-approve.md (delta of
+        // ssi_revenue_recognition_project_operating_unit -- Additional
+        // Post-Condition, itself extending the delta already documented
+        // by ssi_revenue_recognition_project). Navigation is scaffolded
+        // from the base module's own "05-approve" tour Flow
+        // (ssi_revenue_recognition); this delta adds no Flow step of
+        // its own -- per the Keputusan Desain of issue #57, the tour
+        // only runs the Flow through to Open and stops there. It does
+        // not open the Project tab or inspect the created project's
+        // Operating Unit -- that value is unit test territory (see
+        // tests/test_data_performance_obligation.yaml in this module).
+        tour.register(
+            "ssi_revenue_recognition_project_operating_unit_performance_obligation_approve",
+            {test: true, url: "/web"},
+            [
+                // Base Flow 1 -- Open the Cost Accounting > Revenue
+                // Recognition > Performance Obligations menu.
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the Cost Accounting app",
+                    trigger:
+                        '.o_app[data-menu-xmlid="ssi_cost_accounting.menu_root_cost_accounting"]',
+                },
+                {
+                    content: "Open the Revenue Recognition menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.menu_revenue_recognition"]',
+                },
+                {
+                    content: "Open the Performance Obligations menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_revenue_recognition.performance_obligation_menu"]',
+                },
+                {
+                    content: "Performance Obligations list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Performance Obligations)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Base Flow 2 -- Open the record to approve.
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(TOUR-POB-PROJECT-OU-APPROVE) .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Base Flow 3 -- Click the Approve button.
+                {
+                    content: "Click the Approve button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_approve_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Base Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Additional Post-Condition (docs/performance_obligation/
+                // 05-approve.md of this module) -- the single approval
+                // level is fulfilled, so the record is auto-opened
+                // (action_open), which also runs the OU-propagation
+                // side effect this module adds. Per the Keputusan
+                // Desain, the tour stops at this statusbar assertion --
+                // it does not inspect the created project's Operating
+                // Unit value.
+                {
+                    content: "Status is Open",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='open'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        );
+    }
+);

--- a/ssi_revenue_recognition_project_operating_unit/tests/__init__.py
+++ b/ssi_revenue_recognition_project_operating_unit/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_performance_obligation
+from . import test_ui_performance_obligation

--- a/ssi_revenue_recognition_project_operating_unit/tests/test_ui_performance_obligation.py
+++ b/ssi_revenue_recognition_project_operating_unit/tests/test_ui_performance_obligation.py
@@ -1,0 +1,73 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase -- NOT HttpCase. 14.0's plain HttpCase does not set
+# up cls.env in setUpClass, so the Pre-Condition fixture below would
+# fail with AttributeError before the browser even starts (see the UI
+# test skill's structure-and-runner.md, Base class section).
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiPerformanceObligation(HttpSavepointCase):
+    """Tour test for the ``performance_obligation`` IK extension.
+
+    Covers the delta of ``docs/performance_obligation/05-approve.md``
+    added by this module: the Approve Flow still completes and reaches
+    ``open`` for a PoB owned by an Operating Unit. The propagated
+    Operating Unit value on the created project is unit test territory
+    (``tests/test_data_performance_obligation.yaml``), not this tour's.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a PoB pending approval, owned by the main operating unit.
+
+        Pre-Condition of the approve delta tour: the record must be in
+        the ``confirm`` state (Waiting for Approval), and its
+        ``operating_unit_id`` must be one the ``admin`` user (who runs
+        the tour) is assigned to -- otherwise the record rule added by
+        ``ssi_revenue_recognition_operating_unit``
+        (``performance_obligation_rule_ou``) would hide it from the
+        list, and the tour could never find it to open. ``admin`` is
+        granted the base module's approver group and already owns
+        ``operating_unit.main_operating_unit``.
+        ``auto_create_project`` is set so this module's own side
+        effect (project creation, whose Operating Unit follows the
+        PoB) actually runs once the record is approved.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+        cls.env.ref(
+            "ssi_revenue_recognition.performance_obligation_validator_group"
+        ).sudo().write({"users": [(4, cls.admin.id)]})
+        cls.main_ou = cls.env.ref("operating_unit.main_operating_unit")
+
+        AA = cls.env["account.analytic.account"]
+        cls.source_aa = AA.create({"name": "TOUR-POB-PROJECT-OU-SOURCE-AA"})
+
+        Pob = cls.env["performance_obligation"]
+        cls.pob_approve = Pob.create(
+            {
+                "title": "TOUR-POB-PROJECT-OU-APPROVE",
+                "source_analytic_account_id": cls.source_aa.id,
+                "user_id": cls.admin.id,
+                "operating_unit_id": cls.main_ou.id,
+                "auto_create_project": True,
+            }
+        )
+        cls.pob_approve.action_confirm()
+        cls.pob_approve.invalidate_cache()
+
+    def test_approve_reaches_open(self):
+        """Run the approve delta tour for ``performance_obligation``.
+
+        IK: docs/performance_obligation/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_revenue_recognition_project_operating_unit_"
+            "performance_obligation_approve",
+            login="admin",
+        )

--- a/ssi_revenue_recognition_project_operating_unit/views/assets.xml
+++ b/ssi_revenue_recognition_project_operating_unit/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<template
+        id="assets_tests"
+        name="ssi_revenue_recognition_project_operating_unit assets tests"
+        inherit_id="web.assets_tests"
+    >
+    <xpath expr="." position="inside">
+        <script
+                type="text/javascript"
+                src="/ssi_revenue_recognition_project_operating_unit/static/tests/tours/performance_obligation_tour.js"
+            />
+    </xpath>
+</template>
+</odoo>


### PR DESCRIPTION
## Summary

- Tambahkan IK extension `docs/performance_obligation/05-approve.md` yang menautkan ke IK extension `ssi_revenue_recognition_project` (bukan menyalin ulang Flow dasar maupun Flow extension project) dan hanya mendokumentasikan bagian Operating Unit: `project.project` hasil bentukan mengikuti Operating Unit Performance Obligation induknya begitu record mencapai state `open`.
- Tambahkan tour pasangannya (`performance_obligation_tour.js`) yang menjalankan Flow sampai status berpindah ke Open, tanpa memeriksa nilai Operating Unit project hasil bentukan (wilayah unit test), beserta `HttpCase` pemanggil dan pendaftaran aset `web.assets_tests`.
- Tambahkan bagian Work Instruction di README.rst dan dependensi `web_tour` di manifest.

## Validator

```
#VALIDATOR name=module target=ssi_revenue_recognition_project_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik target=ssi_revenue_recognition_project_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour target=ssi_revenue_recognition_project_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-revenue-recognition modules=1 failed=0 skipped=0 status=OK
```

Closes open-synergy/ssi-revenue-recognition#57

🤖 Generated with [Claude Code](https://claude.com/claude-code)