### PR TITLE
[UPD] ssi_revenue_recognition_work_log - tegakkan allowed_work_log_ids di server

### DIFF
--- a/ssi_revenue_recognition_work_log/models/performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition_work_log/models/performance_obligation_acceptance.py
@@ -1,7 +1,8 @@
 # Copyright 2024 OpenSynergy Indonesia
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0-standalone.html).
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class PerformanceObligationAcceptance(models.Model):
@@ -88,3 +89,42 @@ class PerformanceObligationAcceptance(models.Model):
                 result += work_log.amount
             record.qty_work_log = result
             record._compute_qty_fulfilled()
+
+    @api.constrains(
+        "poa_work_log_ids",
+    )
+    def _check_poa_work_log_ids(self):
+        """Reject work logs picked outside ``allowed_work_log_ids``.
+
+        The ``domain=`` restriction on the ``poa_work_log_ids`` widget
+        (``views/performance_obligation_acceptance_views.xml``) only
+        filters what the UI shows — it does not stop ``write()``/
+        ``create()`` performed through the ORM or RPC directly. This
+        constraint re-checks the same membership on the server, so a
+        work log outside the acceptance's ``allowed_work_log_ids``
+        (wrong analytic account, date window, or not in ``done``
+        state) can never end up counted in ``qty_work_log``.
+
+        :raises ValidationError: when ``poa_work_log_ids`` contains at
+            least one work log absent from ``allowed_work_log_ids``.
+        """
+        for record in self:
+            disallowed = record.poa_work_log_ids - record.allowed_work_log_ids
+            for work_log in disallowed:
+                error_message = (
+                    _(
+                        """
+Context: Select work log for %s
+Database ID: %s
+Problem: Work log "%s" is not part of the allowed work logs
+Solution: Select work logs within the acceptance's date window and
+matching the performance obligation's analytic account
+"""
+                    )
+                    % (
+                        record._description.lower(),
+                        record.id,
+                        work_log.description,
+                    )
+                )
+                raise ValidationError(error_message)

--- a/ssi_revenue_recognition_work_log/tests/test_data_performance_obligation_acceptance.yaml
+++ b/ssi_revenue_recognition_work_log/tests/test_data_performance_obligation_acceptance.yaml
@@ -410,3 +410,135 @@ scenarios:
           qty_work_log:
             type: "value"
             expected: 0.0
+
+  - name: "Selecting a work log outside allowed_work_log_ids is rejected"
+    steps:
+      - step: "Create source analytic account of the contract"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_4"
+        values:
+          name: "Test Source AA - POA WL Constrain 4"
+
+      - step: "Create the PoB's own analytic account"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "pob_aa_4"
+        values:
+          name: "Test PoB AA - POA WL Constrain 4"
+
+      - step: "Create an unrelated analytic account (another PoB's)"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "other_aa_4"
+        values:
+          name: "Test Other AA - POA WL Constrain 4"
+
+      - step: "Create the PoB on its own analytic account"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_4"
+        values:
+          title: "Test PoB - POA WL Constrain 4"
+          source_analytic_account_id: "REC: source_aa_4.id"
+          analytic_account_id: "REC: pob_aa_4.id"
+
+      - step: "Create the customer partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner_4"
+        values:
+          name: "Test Customer - POA WL Constrain 4"
+
+      - step: "Create the acceptance's date window"
+        action: "create"
+        model: "performance_obligation_acceptance"
+        save_as: "poa_4"
+        values:
+          partner_id: "REC: partner_4.id"
+          performance_obligation_id: "REC: pob_4.id"
+          date: 2024-04-30
+          date_start: 2024-04-01
+          date_end: 2024-04-30
+
+      - step: "Create employee who will log the work"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee_4"
+        values:
+          name: "Test Employee - POA WL Constrain 4"
+
+      - step: "Open a timesheet covering the acceptance's date window"
+        action: "create"
+        model: "hr.timesheet"
+        save_as: "timesheet_4"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_4.id"
+          date_start: 2024-04-01
+          date_end: 2024-04-30
+
+      - step: "Confirm the timesheet is open"
+        action: "call"
+        target: "timesheet_4"
+        method: "action_open"
+        as_user: "base.user_admin"
+
+      - step: "Get ir.model for res.partner (arbitrary work object type)"
+        action: "search"
+        model: "ir.model"
+        domain: [["model", "=", "res.partner"]]
+        save_as: "ir_model_4"
+        limit: 1
+
+      - step: "Work log outside AA - in window, done, but wrong AA"
+        action: "create"
+        model: "hr.work_log"
+        save_as: "wl_disallowed_4"
+        as_user: "base.user_admin"
+        values:
+          employee_id: "REC: employee_4.id"
+          description: "Disallowed work log (wrong AA)"
+          model_id: "REC: ir_model_4.id"
+          work_object_id: "REC: partner_4.id"
+          date: 2024-04-10
+          amount: 3.0
+          analytic_account_id: "REC: other_aa_4.id"
+
+      - step: "Confirm the disallowed work log"
+        action: "call"
+        target: "wl_disallowed_4"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      - step: "Approve the disallowed work log (moves it to done)"
+        action: "call"
+        target: "wl_disallowed_4"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "Picking a work log outside allowed_work_log_ids is rejected"
+        action: "write"
+        target: "poa_4"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "Disallowed work log (wrong AA)"
+        values:
+          poa_work_log_ids: [[6, 0, ["REC: wl_disallowed_4.id"]]]
+
+      - step: "Rejected write leaves poa_work_log_ids empty"
+        action: "assert"
+        target: "poa_4"
+        asserts:
+          poa_work_log_ids:
+            type: "m2m"
+            check: "count"
+            expected_count: 0

--- a/ssi_revenue_recognition_work_log/tests/test_performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition_work_log/tests/test_performance_obligation_acceptance.py
@@ -12,8 +12,10 @@ class TestPerformanceObligationAcceptance(YamlTransactionCase):
     """Scenario tests for the work log bridge on the acceptance model.
 
     Covers ``_compute_allowed_work_log_ids`` (the curated selection of
-    ``hr.work_log`` candidates) and ``_compute_qty_work_log`` (the
-    quantity summed from the logs actually picked).
+    ``hr.work_log`` candidates), ``_compute_qty_work_log`` (the
+    quantity summed from the logs actually picked), and
+    ``_check_poa_work_log_ids`` (the server-side rejection of any
+    work log picked outside ``allowed_work_log_ids``).
     """
 
     def test_performance_obligation_acceptance(self):


### PR DESCRIPTION
## Ringkasan

Menegakkan pembatasan `allowed_work_log_ids` pada `performance_obligation_acceptance`
di sisi server, bukan hanya di UI (`domain=` pada widget field).

- Tambah `@api.constrains("poa_work_log_ids")` pada
  `performance_obligation_acceptance` (modul `ssi_revenue_recognition_work_log`)
  yang membandingkan `poa_work_log_ids` terhadap `allowed_work_log_ids` dan
  melempar `ValidationError` bila ada selisih (mengikuti konvensi pesan error
  terstruktur SSI).
- Tambah skenario negatif YAML: memilih work log di luar
  `allowed_work_log_ids` (analytic account tidak cocok) → `write()` ditolak
  dengan `ValidationError`.
- Tidak mengubah `_compute_allowed_work_log_ids`/`_compute_qty_work_log` yang
  sudah ada — murni menambah validasi baru.

## Verifikasi

- `verify-module.sh ssi_revenue_recognition_work_log 14.0` → `LOLOS: 0 ERROR`
- `validate-unit-test.sh ssi_revenue_recognition_work_log 14.0` → `LOLOS: 0 ERROR`
- `pre-commit-gate.sh` → `GATE OK: 6 pemeriksaan, 0 pelanggaran baru`

Closes open-synergy/ssi-revenue-recognition#70