### PR TITLE
[UPD] ssi_revenue_recognition_operating_unit - kunci operating_unit_id pasca-done

### DIFF
--- a/ssi_revenue_recognition_operating_unit/models/performance_obligation.py
+++ b/ssi_revenue_recognition_operating_unit/models/performance_obligation.py
@@ -2,7 +2,8 @@
 # Copyright 2022 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 
 class PerformanceObligation(models.Model):
@@ -16,7 +17,7 @@ class PerformanceObligation(models.Model):
     operating unit). It is stamped at creation time by the
     ``ssi_service_revenue_recognition_operating_unit`` bridge, copied
     from the source service contract, and stays a plain, editable
-    field afterwards.
+    field until the document reaches ``done`` -- see ``write()``.
     """
 
     _name = "performance_obligation"
@@ -32,3 +33,32 @@ class PerformanceObligation(models.Model):
         store=True,
         default=False,
     )
+
+    def write(self, vals):
+        """Reject changing ``operating_unit_id`` once ``done``.
+
+        Operating unit is stamped once at creation time and must not
+        move after the performance obligation reaches ``done`` -- the
+        ownership it implies (record rules, analytic reporting) would
+        otherwise change silently underneath a completed document.
+
+        :param vals: values to write, as passed to ``write()``.
+        :raises UserError: when ``vals`` includes
+            ``operating_unit_id`` and at least one record in ``self``
+            is already in ``done`` state.
+        :return: result of ``super().write()``.
+        """
+        if "operating_unit_id" in vals:
+            for record in self.filtered(lambda r: r.state == "done"):
+                error_message = _(
+                    """
+Context: Change operating unit
+Database ID: %s
+Problem: Operating unit cannot be changed once the document is done
+Solution: Restart the document (action_restart) before changing its
+operating unit
+"""
+                    % (record.id,)
+                )
+                raise UserError(error_message)
+        return super().write(vals)

--- a/ssi_revenue_recognition_operating_unit/models/performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition_operating_unit/models/performance_obligation_acceptance.py
@@ -2,7 +2,8 @@
 # Copyright 2022 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 
 class PerformanceObligationAcceptance(models.Model):
@@ -14,7 +15,11 @@ class PerformanceObligationAcceptance(models.Model):
     ``performance_obligation_id.operating_unit_id``, so an acceptance
     always carries its performance obligation's operating unit
     instead of falling back to the acting user's default operating
-    unit.
+    unit. Odoo marks ``related`` fields readonly by default (no
+    explicit ``readonly=`` anywhere in the inheritance chain), but
+    that is a view-layer attribute only -- ``write()`` still tunnels
+    straight through the ORM, so the field stays locked here once the
+    document is ``done``; see ``write()``.
     """
 
     _name = "performance_obligation_acceptance"
@@ -30,3 +35,35 @@ class PerformanceObligationAcceptance(models.Model):
         store=True,
         default=False,
     )
+
+    def write(self, vals):
+        """Reject changing ``operating_unit_id`` once ``done``.
+
+        ``operating_unit_id`` is a stored ``related`` field, marked
+        readonly for the UI only -- a direct ``write()`` (server
+        action, import, RPC) still reaches ``Field.write()`` and
+        succeeds regardless of that UI attribute. This guards the
+        same rule as ``PerformanceObligation.write()`` at this
+        model's own level, since a related write bypasses the
+        parent's constraint entirely.
+
+        :param vals: values to write, as passed to ``write()``.
+        :raises UserError: when ``vals`` includes
+            ``operating_unit_id`` and at least one record in ``self``
+            is already in ``done`` state.
+        :return: result of ``super().write()``.
+        """
+        if "operating_unit_id" in vals:
+            for record in self.filtered(lambda r: r.state == "done"):
+                error_message = _(
+                    """
+Context: Change operating unit
+Database ID: %s
+Problem: Operating unit cannot be changed once the document is done
+Solution: Restart the document (action_restart) before changing its
+operating unit
+"""
+                    % (record.id,)
+                )
+                raise UserError(error_message)
+        return super().write(vals)

--- a/ssi_revenue_recognition_operating_unit/models/revenue_recognition.py
+++ b/ssi_revenue_recognition_operating_unit/models/revenue_recognition.py
@@ -2,7 +2,8 @@
 # Copyright 2022 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 
 class RevenueRecognition(models.Model):
@@ -13,7 +14,12 @@ class RevenueRecognition(models.Model):
     ``performance_obligation_id.operating_unit_id``, keeping the
     performance obligation, its acceptance, and this revenue
     recognition record on the same operating unit instead of falling
-    back to the acting user's default operating unit.
+    back to the acting user's default operating unit. Odoo marks
+    ``related`` fields readonly by default (no explicit ``readonly=``
+    anywhere in the inheritance chain), but that is a view-layer
+    attribute only -- ``write()`` still tunnels straight through the
+    ORM, so the field stays locked here once the document is
+    ``done``; see ``write()``.
     """
 
     _name = "revenue_recognition"
@@ -30,3 +36,35 @@ class RevenueRecognition(models.Model):
         store=True,
         default=False,
     )
+
+    def write(self, vals):
+        """Reject changing ``operating_unit_id`` once ``done``.
+
+        ``operating_unit_id`` is a stored ``related`` field, marked
+        readonly for the UI only -- a direct ``write()`` (server
+        action, import, RPC) still reaches ``Field.write()`` and
+        succeeds regardless of that UI attribute. This guards the
+        same rule as ``PerformanceObligation.write()`` at this
+        model's own level, since a related write bypasses the
+        parent's constraint entirely.
+
+        :param vals: values to write, as passed to ``write()``.
+        :raises UserError: when ``vals`` includes
+            ``operating_unit_id`` and at least one record in ``self``
+            is already in ``done`` state.
+        :return: result of ``super().write()``.
+        """
+        if "operating_unit_id" in vals:
+            for record in self.filtered(lambda r: r.state == "done"):
+                error_message = _(
+                    """
+Context: Change operating unit
+Database ID: %s
+Problem: Operating unit cannot be changed once the document is done
+Solution: Restart the document (action_restart) before changing its
+operating unit
+"""
+                    % (record.id,)
+                )
+                raise UserError(error_message)
+        return super().write(vals)

--- a/ssi_revenue_recognition_operating_unit/tests/test_data_performance_obligation.yaml
+++ b/ssi_revenue_recognition_operating_unit/tests/test_data_performance_obligation.yaml
@@ -100,3 +100,74 @@ scenarios:
         as_user: "restricted_user"
         expect_error:
           type: "AccessError"
+
+  - name: "write operating_unit_id on a done PoB is rejected (issue #72)"
+    steps:
+      - step: "Create draft PoB on the first operating unit as admin"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob"
+        as_user: "base.user_admin"
+        values:
+          title: "Test PoB - OU Locked After Done"
+          source_analytic_account_id: "REC: source_aa.id"
+          operating_unit_id: "REC: ou_1.id"
+
+      - step: "Confirm the PoB"
+        action: "call"
+        target: "pob"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04).
+      - step: "PoB is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "pob"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the PoB (auto-runs action_open via _after_approved_method)"
+        action: "call"
+        target: "pob"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Move the PoB to done"
+        action: "call"
+        target: "pob"
+        method: "action_done"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "Writing operating_unit_id on the done PoB is rejected"
+        action: "write"
+        target: "pob"
+        as_user: "base.user_admin"
+        values:
+          operating_unit_id: "REC: ou_2.id"
+        expect_error:
+          type: "UserError"
+          message_contains: "Operating unit cannot be changed"
+
+      - step: "operating_unit_id stays the first operating unit, unchanged"
+        action: "assert"
+        refresh: true
+        target: "pob"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: ou_1"

--- a/ssi_revenue_recognition_operating_unit/tests/test_data_performance_obligation_acceptance.yaml
+++ b/ssi_revenue_recognition_operating_unit/tests/test_data_performance_obligation_acceptance.yaml
@@ -77,3 +77,67 @@ scenarios:
           operating_unit_id:
             type: "m2o"
             expected: "REC: ou_2"
+
+  - name: "write operating_unit_id on a done acceptance is rejected (issue #72)"
+    steps:
+      - step: "Create a draft acceptance for the PoB as admin"
+        action: "create"
+        model: "performance_obligation_acceptance"
+        save_as: "acceptance"
+        as_user: "base.user_admin"
+        values:
+          partner_id: "REC: customer.id"
+          performance_obligation_id: "REC: pob.id"
+          date: 2024-01-31
+          date_start: 2024-01-01
+          date_end: 2024-01-31
+
+      - step: "Confirm the acceptance"
+        action: "call"
+        target: "acceptance"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04).
+      - step: "Acceptance is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "acceptance"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step:
+          "Approve the acceptance (auto-runs action_done via _after_approved_method)"
+        action: "call"
+        target: "acceptance"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "Writing operating_unit_id on the done acceptance is rejected"
+        action: "write"
+        target: "acceptance"
+        as_user: "base.user_admin"
+        values:
+          operating_unit_id: "REC: ou_1.id"
+        expect_error:
+          type: "UserError"
+          message_contains: "Operating unit cannot be changed"
+
+      - step: "operating_unit_id stays the PoB's second operating unit"
+        action: "assert"
+        refresh: true
+        target: "acceptance"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: ou_2"

--- a/ssi_revenue_recognition_operating_unit/tests/test_data_revenue_recognition.yaml
+++ b/ssi_revenue_recognition_operating_unit/tests/test_data_revenue_recognition.yaml
@@ -145,3 +145,83 @@ scenarios:
           operating_unit_id:
             type: "m2o"
             expected: "REC: ou_2"
+
+  - name:
+      "write operating_unit_id on a done revenue recognition is rejected (issue #72)"
+    steps:
+      - step: "Create the first operating unit, different from the PoB's"
+        action: "create"
+        model: "operating.unit"
+        save_as: "ou_1"
+        values:
+          name:
+            "EVAL: 'Test RR OU Locked 1 %d' % env['operating.unit'].search_count([])"
+          code: "EVAL: 'RROULK1%d' % env['operating.unit'].search_count([])"
+          partner_id: "REC: ou_partner.id"
+
+      - step: "Create a draft revenue recognition for the PoB as admin"
+        action: "create"
+        model: "revenue_recognition"
+        save_as: "rr"
+        as_user: "base.user_admin"
+        values:
+          type_id: "REC: rrt.id"
+          partner_id: "REC: customer.id"
+          performance_obligation_id: "REC: pob.id"
+          date: 2024-01-31
+          date_start: 2024-01-01
+          date_end: 2024-01-31
+          journal_id: "REC: journal.id"
+          unearned_income_account_id: "REC: unearned_account.id"
+          income_account_id: "REC: income_account.id"
+
+      - step: "Confirm the revenue recognition"
+        action: "call"
+        target: "rr"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04).
+      - step: "Revenue recognition is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "rr"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step:
+          "Approve the revenue recognition (auto-runs action_done via
+          _after_approved_method)"
+        action: "call"
+        target: "rr"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "Writing operating_unit_id on the done revenue recognition is rejected"
+        action: "write"
+        target: "rr"
+        as_user: "base.user_admin"
+        values:
+          operating_unit_id: "REC: ou_1.id"
+        expect_error:
+          type: "UserError"
+          message_contains: "Operating unit cannot be changed"
+
+      - step: "operating_unit_id stays the PoB's second operating unit"
+        action: "assert"
+        refresh: true
+        target: "rr"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: ou_2"

--- a/ssi_revenue_recognition_operating_unit/tests/test_performance_obligation.py
+++ b/ssi_revenue_recognition_operating_unit/tests/test_performance_obligation.py
@@ -16,7 +16,9 @@ class TestPerformanceObligation(YamlTransactionCase):
     the acting user's default operating unit -- and a user who is
     only granted the second operating unit's sibling group but not
     assigned to that operating unit is denied read access to a PoB
-    owned by it.
+    owned by it. Also covers issue #72: once the PoB reaches
+    ``done``, writing ``operating_unit_id`` is rejected with a
+    ``UserError`` instead of silently going through.
     """
 
     def test_performance_obligation(self):

--- a/ssi_revenue_recognition_operating_unit/tests/test_performance_obligation_acceptance.py
+++ b/ssi_revenue_recognition_operating_unit/tests/test_performance_obligation_acceptance.py
@@ -15,7 +15,10 @@ class TestPerformanceObligationAcceptance(YamlTransactionCase):
     field mirroring ``performance_obligation_id.operating_unit_id``,
     so an acceptance always carries its performance obligation's
     operating unit -- proven here with an operating unit that is not
-    the acting user's default one.
+    the acting user's default one. Also covers issue #72: once the
+    acceptance reaches ``done``, writing ``operating_unit_id`` is
+    rejected with a ``UserError`` even though the related field is
+    only readonly at the UI layer.
     """
 
     def test_performance_obligation_acceptance(self):

--- a/ssi_revenue_recognition_operating_unit/tests/test_revenue_recognition.py
+++ b/ssi_revenue_recognition_operating_unit/tests/test_revenue_recognition.py
@@ -15,7 +15,10 @@ class TestRevenueRecognition(YamlTransactionCase):
     field mirroring ``performance_obligation_id.operating_unit_id``,
     so a revenue recognition always carries its performance
     obligation's operating unit -- proven here with an operating unit
-    that is not the acting user's default one.
+    that is not the acting user's default one. Also covers issue
+    #72: once the revenue recognition reaches ``done``, writing
+    ``operating_unit_id`` is rejected with a ``UserError`` even
+    though the related field is only readonly at the UI layer.
     """
 
     def test_revenue_recognition(self):


### PR DESCRIPTION
## Ringkasan

Menambahkan override `write()` pada `performance_obligation`,
`performance_obligation_acceptance`, dan `revenue_recognition` (modul
`ssi_revenue_recognition_operating_unit`) yang menolak perubahan
`operating_unit_id` dengan `UserError` begitu dokumen sudah berstate
`done`.

Sebelumnya field ini tetap tertembus ORM/RPC meski ditandai `readonly` di
UI (khusus dua model `related` field: `readonly` hanya atribut tampilan,
bukan penegakan level ORM — `BaseModel.write()` tetap memanggil
`field.write()` untuk setiap key di `vals` tanpa syarat `readonly`).

## Perubahan

- `models/performance_obligation.py`, `performance_obligation_acceptance.py`,
  `revenue_recognition.py`: override `write()` menolak key
  `operating_unit_id` saat `self.filtered(lambda r: r.state == "done")`.
- `tests/test_data_performance_obligation.yaml`,
  `test_data_performance_obligation_acceptance.yaml`,
  `test_data_revenue_recognition.yaml`: skenario negatif yang membawa
  dokumen ke state `done` lalu membuktikan write `operating_unit_id`
  ditolak dengan `UserError`.
- Docstring class & docstring test method diperbarui agar sesuai dengan
  perilaku baru.

## Kriteria Penerimaan

- [x] Write `operating_unit_id` pada `performance_obligation` ber-state
      `done` → `UserError`
- [x] Write `operating_unit_id` pada `performance_obligation_acceptance`
      ber-state `done` → `UserError`
- [x] Write `operating_unit_id` pada `revenue_recognition` ber-state
      `done` → `UserError`
- [x] Skenario positif (create, perambatan OU) yang sudah ada di issue
      #59 tidak terpengaruh (tidak diubah)
- [x] `git diff` tidak mengubah `operating_unit_id` di state selain
      `done`

Closes open-synergy/ssi-revenue-recognition#72