### PR TITLE
[UPD] ssi_revenue_recognition_operating_unit - propagasi OU ke account.move

### DIFF
--- a/ssi_revenue_recognition_operating_unit/__manifest__.py
+++ b/ssi_revenue_recognition_operating_unit/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": [
         "ssi_revenue_recognition",
         "ssi_operating_unit_mixin",
+        "account_operating_unit",
         "web_tour",
     ],
     "data": [

--- a/ssi_revenue_recognition_operating_unit/models/revenue_recognition.py
+++ b/ssi_revenue_recognition_operating_unit/models/revenue_recognition.py
@@ -20,6 +20,13 @@ class RevenueRecognition(models.Model):
     attribute only -- ``write()`` still tunnels straight through the
     ORM, so the field stays locked here once the document is
     ``done``; see ``write()``.
+
+    Also propagates ``operating_unit_id`` onto the ``account.move``
+    (and its lines) that ``_create_accounting_entry()`` posts when
+    this record reaches ``done``, so the accounting entry stays on
+    the same operating unit as this record instead of falling back
+    to the posting user's default operating unit -- see
+    ``_prepare_account_move()`` and ``_prepare_ml()``.
     """
 
     _name = "revenue_recognition"
@@ -68,3 +75,36 @@ operating unit
                 )
                 raise UserError(error_message)
         return super().write(vals)
+
+    def _prepare_account_move(self):
+        """Build the header values of the ``account.move`` to create.
+
+        Extends the base header with ``operating_unit_id`` so the
+        accounting entry created by ``_create_accounting_entry()``
+        carries this record's operating unit instead of falling back
+        to the posting user's default operating unit.
+
+        :return: dict of ``account.move`` values
+        """
+        self.ensure_one()
+        res = super()._prepare_account_move()
+        res["operating_unit_id"] = self.operating_unit_id.id
+        return res
+
+    def _prepare_ml(self, account, debit, credit):
+        """Build the common ``account.move.line`` values, with the OU.
+
+        Extends the base line values with ``operating_unit_id`` so
+        every move line created against ``move_id`` (income, unearned
+        income) carries this record's operating unit, mirroring
+        ``_prepare_account_move()`` at the line level.
+
+        :param account: an ``account.account`` record
+        :param debit: debit amount
+        :param credit: credit amount
+        :return: dict of ``account.move.line`` values
+        """
+        self.ensure_one()
+        res = super()._prepare_ml(account=account, debit=debit, credit=credit)
+        res["operating_unit_id"] = self.operating_unit_id.id
+        return res

--- a/ssi_revenue_recognition_operating_unit/tests/test_data_revenue_recognition.yaml
+++ b/ssi_revenue_recognition_operating_unit/tests/test_data_revenue_recognition.yaml
@@ -225,3 +225,172 @@ scenarios:
           operating_unit_id:
             type: "m2o"
             expected: "REC: ou_2"
+
+  - name:
+      "A revenue recognition reaching done propagates its operating unit to the
+      account.move it creates (issue #82)"
+    steps:
+      - step: "Create a draft revenue recognition for the PoB on the 2nd OU"
+        action: "create"
+        model: "revenue_recognition"
+        save_as: "rr"
+        as_user: "base.user_admin"
+        values:
+          type_id: "REC: rrt.id"
+          partner_id: "REC: customer.id"
+          performance_obligation_id: "REC: pob.id"
+          date: 2024-01-31
+          date_start: 2024-01-01
+          date_end: 2024-01-31
+          journal_id: "REC: journal.id"
+          unearned_income_account_id: "REC: unearned_account.id"
+          income_account_id: "REC: income_account.id"
+
+      - step: "Confirm the revenue recognition"
+        action: "call"
+        target: "rr"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04).
+      - step: "Revenue recognition is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "rr"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step:
+          "Approve the revenue recognition (auto-runs action_done, which posts the
+          accounting entry via _create_accounting_entry)"
+        action: "call"
+        target: "rr"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "The created account.move carries the same operating unit as rr"
+        action: "assert"
+        refresh: true
+        target: "rr"
+        asserts:
+          move_id.operating_unit_id:
+            type: "m2o"
+            expected: "REC: ou_2"
+
+      - step: "The move has both the income and unearned income lines"
+        action: "assert"
+        target: "rr"
+        asserts:
+          move_id.line_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 2
+
+      - step:
+          "No line of the created move deviates from rr's operating unit (income and
+          unearned income lines alike)"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          - ["move_id", "=", "REC: rr.move_id.id"]
+          - ["operating_unit_id", "!=", "REC: ou_2.id"]
+        save_as: "deviating_ml"
+        expect_count: 0
+
+  - name:
+      "A revenue recognition without an operating unit reaching done leaves its
+      account.move without one (issue #82)"
+    steps:
+      - step: "Create the analytic account of the OU-less PoB"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "source_aa_no_ou"
+        values:
+          name:
+            "EVAL: 'Test RR OU No-OU Source AA %d' %
+            env['account.analytic.account'].search_count([])"
+
+      - step: "Create the Performance Obligation without an operating unit"
+        action: "create"
+        model: "performance_obligation"
+        save_as: "pob_no_ou"
+        values:
+          title: "Test PoB - RR OU No-OU Parent"
+          source_analytic_account_id: "REC: source_aa_no_ou.id"
+
+      - step: "PoB has no operating unit"
+        action: "assert"
+        target: "pob_no_ou"
+        asserts:
+          operating_unit_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Create a draft revenue recognition for the OU-less PoB"
+        action: "create"
+        model: "revenue_recognition"
+        save_as: "rr_no_ou"
+        as_user: "base.user_admin"
+        values:
+          type_id: "REC: rrt.id"
+          partner_id: "REC: customer.id"
+          performance_obligation_id: "REC: pob_no_ou.id"
+          date: 2024-01-31
+          date_start: 2024-01-01
+          date_end: 2024-01-31
+          journal_id: "REC: journal.id"
+          unearned_income_account_id: "REC: unearned_account.id"
+          income_account_id: "REC: income_account.id"
+
+      - step: "Confirm the revenue recognition"
+        action: "call"
+        target: "rr_no_ou"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+
+      # WAJIB: memaksa refresh sebelum approval dibaca (T-04).
+      - step: "Revenue recognition is confirm before approving"
+        action: "assert"
+        refresh: true
+        target: "rr_no_ou"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step:
+          "Approve the revenue recognition (auto-runs action_done, which posts the
+          accounting entry via _create_accounting_entry)"
+        action: "call"
+        target: "rr_no_ou"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step:
+          "The created account.move has no operating unit either -- the default is not
+          silently applied"
+        action: "assert"
+        refresh: true
+        target: "rr_no_ou"
+        asserts:
+          move_id.operating_unit_id:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_revenue_recognition_operating_unit/tests/test_revenue_recognition.py
+++ b/ssi_revenue_recognition_operating_unit/tests/test_revenue_recognition.py
@@ -18,7 +18,12 @@ class TestRevenueRecognition(YamlTransactionCase):
     that is not the acting user's default one. Also covers issue
     #72: once the revenue recognition reaches ``done``, writing
     ``operating_unit_id`` is rejected with a ``UserError`` even
-    though the related field is only readonly at the UI layer.
+    though the related field is only readonly at the UI layer. Also
+    covers issue #82: the ``account.move`` (and its lines) posted by
+    ``_create_accounting_entry()`` when the document reaches ``done``
+    carries the same operating unit as this record -- including the
+    negative case where the record has none, proving the default is
+    not silently applied.
     """
 
     def test_revenue_recognition(self):


### PR DESCRIPTION
## Ringkasan

Menambahkan propagasi `operating_unit_id` dari `revenue_recognition` ke
`account.move` (dan setiap `account.move.line`-nya) yang dibuat
`_create_accounting_entry()` saat dokumen mencapai `done`.

Sebelumnya `account.move` tidak punya mekanisme apa pun untuk mewarisi
`operating_unit_id` -- modul `ssi_revenue_recognition_operating_unit` tidak
`depends` pada `account_operating_unit` (modul OCA yang menambahkan field itu
ke `account.move`), dan `_prepare_account_move()`/`_prepare_ml()` tidak
menyertakannya di `values`-nya.

## Perubahan

- `__manifest__.py`: tambah `account_operating_unit` ke `depends`.
- `models/revenue_recognition.py`: override `_prepare_account_move()` (header
  move) dan `_prepare_ml()` (setiap move line: income, unearned income) agar
  menyuntikkan `operating_unit_id` dari `self.operating_unit_id`.
- `tests/test_data_revenue_recognition.yaml`: skenario positif (move header +
  setiap baris ber-OU sama dengan dokumen) dan skenario negatif
  (`revenue_recognition` tanpa OU tidak menyuntikkan default secara keliru ke
  move-nya).
- Docstring class & test terkait diperbarui.

## Kriteria Penerimaan

- [x] `ssi_revenue_recognition_operating_unit/__manifest__.py` memuat
      `account_operating_unit` di `depends`
- [x] `account.move` yang dibuat `_create_accounting_entry()` memikul
      `operating_unit_id` sama dengan `revenue_recognition`-nya
- [x] Setiap `account.move.line` yang dibuat (`_prepare_ml`) memikul
      `operating_unit_id` yang sama
- [x] `verify-module.sh` mencetak `LOLOS: 0 ERROR` untuk modul ini

## Test plan

- [x] `verify-module.sh` -> `LOLOS: 0 ERROR`
- [x] `validate-unit-test.sh` -> `LOLOS: 0 ERROR`
- [x] `pre-commit-gate.sh` -> `GATE OK`
- [ ] CI GitHub hijau

Closes open-synergy/ssi-revenue-recognition#82