### PR TITLE
[UPD] ssi_revenue_recognition: pulihkan blok metadata IK agar stabil terhadap prettier

### DIFF
--- a/ssi_revenue_recognition/docs/performance_obligation/01-create.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/01-create.md
@@ -1,8 +1,14 @@
 # Create Performance Obligation
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
-> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
-> group \_Performance Obligation — User* > **State:** `—` → `draft`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligations
+>
+> **Actor:** user in group _Performance Obligation — User_
+>
+> **State:** `—` → `draft`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation/02-edit.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/02-edit.md
@@ -1,8 +1,14 @@
 # Edit Performance Obligation
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
-> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
-> group \_Performance Obligation — User* > **Requires:** `01-create`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligations
+>
+> **Actor:** user in group _Performance Obligation — User_
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation/03-delete.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/03-delete.md
@@ -1,8 +1,14 @@
 # Delete Performance Obligation
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
-> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
-> group \_Performance Obligation — User* > **Requires:** `01-create`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligations
+>
+> **Actor:** user in group _Performance Obligation — User_
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation/04-confirm.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/04-confirm.md
@@ -1,9 +1,16 @@
 # Confirm Performance Obligation
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
-> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
-> group \_Performance Obligation — User* > **State:** `draft` → `confirm` >
-> **Requires:** > `01-create`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligations
+>
+> **Actor:** user in group _Performance Obligation — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation/05-approve.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/05-approve.md
@@ -1,8 +1,15 @@
 # Approve Performance Obligation
 
-> **Module:** ssi_revenue_recognition **Model:** `performance_obligation` > **Menu:**
-> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** approver on
-> the approval level that is currently pending **State:** `confirm` → `open` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligations
+>
+> **Actor:** approver on the approval level that is currently pending
+>
+> **State:** `confirm` → `open`
+>
 > **Requires:** `04-confirm`
 
 ## Pre-Condition

--- a/ssi_revenue_recognition/docs/performance_obligation/06-reject.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/06-reject.md
@@ -1,8 +1,15 @@
 # Reject Performance Obligation
 
-> **Module:** ssi_revenue_recognition **Model:** `performance_obligation` > **Menu:**
-> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** approver on
-> the approval level that is currently pending **State:** `confirm` → `reject` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligations
+>
+> **Actor:** approver on the approval level that is currently pending
+>
+> **State:** `confirm` → `reject`
+>
 > **Requires:** `04-confirm`
 
 ## Pre-Condition

--- a/ssi_revenue_recognition/docs/performance_obligation/09-auto-done.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/09-auto-done.md
@@ -1,8 +1,15 @@
 # Auto-Finish Performance Obligation
 
-> **Module:** ssi_revenue_recognition **Model:** `performance_obligation` > **Menu:**
-> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** System —
-> triggered automatically, no user interaction **State:** `open` → `done` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligations
+>
+> **Actor:** System — triggered automatically, no user interaction
+>
+> **State:** `open` → `done`
+>
 > **Requires:** `05-approve`
 
 There is no **Done** button on this model (`_automatically_insert_done_button = False`).

--- a/ssi_revenue_recognition/docs/performance_obligation/10-cancel.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/10-cancel.md
@@ -1,8 +1,15 @@
 # Cancel Performance Obligation
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
-> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
-> group \_Performance Obligation — User* > **State:** `draft` | `open` → `cancel` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligations
+>
+> **Actor:** user in group _Performance Obligation — User_
+>
+> **State:** `draft` | `open` → `cancel`
+>
 > **Requires:** `01-create`
 
 ## Pre-Condition

--- a/ssi_revenue_recognition/docs/performance_obligation/12-restart.md
+++ b/ssi_revenue_recognition/docs/performance_obligation/12-restart.md
@@ -1,9 +1,16 @@
 # Restart Performance Obligation
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation` > **Menu:**
-> Cost Accounting > Revenue Recognition > Performance Obligations **Actor:** user in
-> group \_Performance Obligation — Validator* > **State:** `cancel` | `reject` →
-> `draft` > **Requires:** `10-cancel`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Performance Obligations
+>
+> **Actor:** user in group _Performance Obligation — Validator_
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/01-create.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/01-create.md
@@ -1,9 +1,14 @@
 # Create Performance Obligation Acceptance
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation_acceptance`
+>
 > **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
-> **Actor:** user in group \_Performance Obligation Acceptance — User* > **State:** `—`
-> → `draft`
+>
+> **Actor:** user in group _Performance Obligation Acceptance — User_
+>
+> **State:** `—` → `draft`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/02-edit.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/02-edit.md
@@ -1,9 +1,14 @@
 # Edit Performance Obligation Acceptance
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation_acceptance`
+>
 > **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
-> **Actor:** user in group \_Performance Obligation Acceptance — User* > **Requires:** >
-> `01-create`
+>
+> **Actor:** user in group _Performance Obligation Acceptance — User_
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/03-delete.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/03-delete.md
@@ -1,9 +1,14 @@
 # Delete Performance Obligation Acceptance
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation_acceptance`
+>
 > **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
-> **Actor:** user in group \_Performance Obligation Acceptance — User* > **Requires:** >
-> `01-create`
+>
+> **Actor:** user in group _Performance Obligation Acceptance — User_
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/04-confirm.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/04-confirm.md
@@ -1,9 +1,16 @@
 # Confirm Performance Obligation Acceptance
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation_acceptance`
+>
 > **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
-> **Actor:** user in group \_Performance Obligation Acceptance — User* > **State:** >
-> `draft` → `confirm` > **Requires:** `01-create`
+>
+> **Actor:** user in group _Performance Obligation Acceptance — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/05-approve.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/05-approve.md
@@ -1,9 +1,16 @@
 # Approve Performance Obligation Acceptance
 
-> **Module:** ssi_revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation_acceptance`
+>
 > **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
-> **Actor:** approver on the approval level that is currently pending **State:** >
-> `confirm` → `done` > **Requires:** `04-confirm`
+>
+> **Actor:** approver on the approval level that is currently pending
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/06-reject.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/06-reject.md
@@ -1,9 +1,16 @@
 # Reject Performance Obligation Acceptance
 
-> **Module:** ssi_revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation_acceptance`
+>
 > **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
-> **Actor:** approver on the approval level that is currently pending **State:** >
-> `confirm` → `reject` > **Requires:** `04-confirm`
+>
+> **Actor:** approver on the approval level that is currently pending
+>
+> **State:** `confirm` → `reject`
+>
+> **Requires:** `04-confirm`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/10-cancel.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/10-cancel.md
@@ -1,9 +1,16 @@
 # Cancel Performance Obligation Acceptance
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation_acceptance`
+>
 > **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
-> **Actor:** user in group \_Performance Obligation Acceptance — Validator* >
-> **State:** > `draft` | `confirm` | `done` → `cancel` > **Requires:** `01-create`
+>
+> **Actor:** user in group _Performance Obligation Acceptance — Validator_
+>
+> **State:** `draft` | `confirm` | `done` → `cancel`
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/12-restart.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/12-restart.md
@@ -1,9 +1,16 @@
 # Restart Performance Obligation Acceptance
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation_acceptance`
+>
 > **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
-> **Actor:** user in group \_Performance Obligation Acceptance — Validator* >
-> **State:** > `cancel` | `reject` → `draft` > **Requires:** `10-cancel`
+>
+> **Actor:** user in group _Performance Obligation Acceptance — Validator_
+>
+> **State:** `cancel` | `reject` → `draft`
+>
+> **Requires:** `10-cancel`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/performance_obligation_acceptance/14-restart-approval.md
+++ b/ssi_revenue_recognition/docs/performance_obligation_acceptance/14-restart-approval.md
@@ -1,8 +1,13 @@
 # Restart Approval Process — Performance Obligation Acceptance
 
-> **Module:** ssi*revenue_recognition **Model:** `performance_obligation_acceptance` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `performance_obligation_acceptance`
+>
 > **Menu:** Cost Accounting > Revenue Recognition > Performance Obligation Acceptances
-> **Actor:** user in group \_Performance Obligation Acceptance — Validator* >
+>
+> **Actor:** user in group _Performance Obligation Acceptance — Validator_
+>
 > **Requires:** `04-confirm`
 
 ## Pre-Condition

--- a/ssi_revenue_recognition/docs/revenue_recognition/01-create.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/01-create.md
@@ -1,9 +1,16 @@
 # Create Revenue Recognition
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
-> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
-> \_Revenue Recognition — User* > **State:** `—` → `draft` > **Inline Actions:** >
-> `action_populate` (Populate)
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Revenue Recognitions
+>
+> **Actor:** user in group _Revenue Recognition — User_
+>
+> **State:** `—` → `draft`
+>
+> **Inline Actions:** `action_populate` (Populate)
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition/02-edit.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/02-edit.md
@@ -1,9 +1,16 @@
 # Edit Revenue Recognition
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
-> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
-> \_Revenue Recognition — User* > **Requires:** `01-create` > **Inline Actions:** >
-> `action_populate` (Populate)
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Revenue Recognitions
+>
+> **Actor:** user in group _Revenue Recognition — User_
+>
+> **Requires:** `01-create`
+>
+> **Inline Actions:** `action_populate` (Populate)
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition/03-delete.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/03-delete.md
@@ -1,8 +1,14 @@
 # Delete Revenue Recognition
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
-> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
-> \_Revenue Recognition — User* > **Requires:** `01-create`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Revenue Recognitions
+>
+> **Actor:** user in group _Revenue Recognition — User_
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition/04-confirm.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/04-confirm.md
@@ -1,9 +1,16 @@
 # Confirm Revenue Recognition
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
-> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
-> \_Revenue Recognition — User* > **State:** `draft` → `confirm` > **Requires:** >
-> `01-create`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Revenue Recognitions
+>
+> **Actor:** user in group _Revenue Recognition — User_
+>
+> **State:** `draft` → `confirm`
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition/05-approve.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/05-approve.md
@@ -1,9 +1,16 @@
 # Approve Revenue Recognition
 
-> **Module:** ssi_revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
-> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** approver on the
-> approval level that is currently pending **State:** `confirm` → `done` >
-> **Requires:** > `04-confirm`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Revenue Recognitions
+>
+> **Actor:** approver on the approval level that is currently pending
+>
+> **State:** `confirm` → `done`
+>
+> **Requires:** `04-confirm`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition/06-reject.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/06-reject.md
@@ -1,8 +1,15 @@
 # Reject Revenue Recognition
 
-> **Module:** ssi_revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
-> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** approver on the
-> approval level that is currently pending **State:** `confirm` → `reject` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Revenue Recognitions
+>
+> **Actor:** approver on the approval level that is currently pending
+>
+> **State:** `confirm` → `reject`
+>
 > **Requires:** `04-confirm`
 
 ## Pre-Condition

--- a/ssi_revenue_recognition/docs/revenue_recognition/10-cancel.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/10-cancel.md
@@ -1,9 +1,16 @@
 # Cancel Revenue Recognition
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
-> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
-> \_Revenue Recognition — Validator* > **State:** `draft` | `confirm` | `done` →
-> `cancel` > **Requires:** `01-create`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Revenue Recognitions
+>
+> **Actor:** user in group _Revenue Recognition — Validator_
+>
+> **State:** `draft` | `confirm` | `done` → `cancel`
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition/12-restart.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/12-restart.md
@@ -1,8 +1,15 @@
 # Restart Revenue Recognition
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
-> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
-> \_Revenue Recognition — Validator* > **State:** `cancel` | `reject` → `draft` >
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Revenue Recognitions
+>
+> **Actor:** user in group _Revenue Recognition — Validator_
+>
+> **State:** `cancel` | `reject` → `draft`
+>
 > **Requires:** `10-cancel`
 
 ## Pre-Condition

--- a/ssi_revenue_recognition/docs/revenue_recognition/14-restart-approval.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition/14-restart-approval.md
@@ -1,8 +1,14 @@
 # Restart Approval Process — Revenue Recognition
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition` > **Menu:** Cost
-> Accounting > Revenue Recognition > Revenue Recognitions **Actor:** user in group
-> \_Revenue Recognition — Validator* > **Requires:** `04-confirm`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition`
+>
+> **Menu:** Cost Accounting > Revenue Recognition > Revenue Recognitions
+>
+> **Actor:** user in group _Revenue Recognition — Validator_
+>
+> **Requires:** `04-confirm`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition_type/01-create.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition_type/01-create.md
@@ -1,9 +1,17 @@
 # Create Revenue Recognition Type
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition_type` > **Menu:**
-> Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition Types
-> **Actor:** user in group \_Revenue Recognition Type — Configurator* > **State:** `—` →
-> `draft` > **Inline Actions:** `action_generate_code` (Generate Code)
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition_type`
+>
+> **Menu:** Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition
+> Types
+>
+> **Actor:** user in group _Revenue Recognition Type — Configurator_
+>
+> **State:** `—` → `draft`
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition_type/02-edit.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition_type/02-edit.md
@@ -1,9 +1,17 @@
 # Edit Revenue Recognition Type
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition_type` > **Menu:**
-> Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition Types
-> **Actor:** user in group \_Revenue Recognition Type — Configurator* > **Requires:** >
-> `01-create` > **Inline Actions:** `action_generate_code` (Generate Code)
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition_type`
+>
+> **Menu:** Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition
+> Types
+>
+> **Actor:** user in group _Revenue Recognition Type — Configurator_
+>
+> **Requires:** `01-create`
+>
+> **Inline Actions:** `action_generate_code` (Generate Code)
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition_type/03-delete.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition_type/03-delete.md
@@ -1,9 +1,15 @@
 # Delete Revenue Recognition Type
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition_type` > **Menu:**
-> Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition Types
-> **Actor:** user in group \_Revenue Recognition Type — Configurator* > **Requires:** >
-> `01-create`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition_type`
+>
+> **Menu:** Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition
+> Types
+>
+> **Actor:** user in group _Revenue Recognition Type — Configurator_
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition_type/04-deactivate.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition_type/04-deactivate.md
@@ -1,9 +1,17 @@
 # Deactivate Revenue Recognition Type
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition_type` > **Menu:**
-> Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition Types
-> **Actor:** user in group \_Revenue Recognition Type — Configurator* > **Active:** >
-> `true` → `false` > **Requires:** `01-create`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition_type`
+>
+> **Menu:** Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition
+> Types
+>
+> **Actor:** user in group _Revenue Recognition Type — Configurator_
+>
+> **Active:** `true` → `false`
+>
+> **Requires:** `01-create`
 
 ## Pre-Condition
 

--- a/ssi_revenue_recognition/docs/revenue_recognition_type/05-activate.md
+++ b/ssi_revenue_recognition/docs/revenue_recognition_type/05-activate.md
@@ -1,9 +1,17 @@
 # Activate Revenue Recognition Type
 
-> **Module:** ssi*revenue_recognition **Model:** `revenue_recognition_type` > **Menu:**
-> Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition Types
-> **Actor:** user in group \_Revenue Recognition Type — Configurator* > **Active:** >
-> `false` → `true` > **Requires:** `04-deactivate`
+> **Module:** `ssi_revenue_recognition`
+>
+> **Model:** `revenue_recognition_type`
+>
+> **Menu:** Cost Accounting > Configuration > Revenue Recognition > Revenue Recognition
+> Types
+>
+> **Actor:** user in group _Revenue Recognition Type — Configurator_
+>
+> **Active:** `false` → `true`
+>
+> **Requires:** `04-deactivate`
 
 ## Pre-Condition
 


### PR DESCRIPTION
Blok metadata pada 32 berkas Instruksi Kerja `ssi_revenue_recognition` sebelumnya
dilebur prettier (`proseWrap: always` + `printWidth: 88`) menjadi satu paragraf,
sehingga kunci `**Actor:**`/`**Menu:**`/`**Model:**` berpindah ke tengah baris dan
tidak lagi terbaca validator `ik` (73 ERROR). Peleburan itu juga merusak emphasis
(`ssi*revenue_recognition`, `\_Revenue Recognition — User*`).

## Perubahan

* Tiap kunci metadata kini ditulis sebagai paragraf tersendiri di dalam blockquote,
  dipisah baris `>` kosong — prettier tidak pernah melebur dua paragraf, jadi kunci
  tetap berada di awal baris.
* Nilai `Module:` ditulis dalam backtick; `Actor:` memakai emphasis yang utuh.
* Urutan kunci dibakukan: `Module`, `Model`, `Menu`, `Actor`, lalu `State`/`Active`,
  `Requires`, `Inline Actions`.
* Nilai yang teracak reflow dipulihkan apa adanya — tidak ada nilai yang dikarang.

## Verifikasi

* `validate-ik.sh` — `error=0` (semula 73), 32 dari 32 berkas punya blok metadata.
* `pre-commit run prettier` dua kali berturut-turut: putaran kedua nol perubahan.
* `pre-commit-gate.sh` — `GATE OK`, 6 pemeriksaan, 0 pelanggaran baru.
* `git diff` hanya menyentuh baris blockquote metadata; Flow, Pre-Condition, dan
  Post-Condition identik dengan sebelumnya.

Closes #91